### PR TITLE
Link should redirect user to a filtered CVE table

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -13,7 +13,7 @@ const VULN_CVES = '/vulnerability/v1/vulnerabilities/cves';
 export const COMPLIANCE_FETCH_URL = `${BASE_URL}/compliance/profiles`;
 
 export const CRITICAL_VULNERABILITIES_FETCH_URL = urijs(`${BASE_URL}${VULN_CVES}`)
-.addSearch('cvss_from', 7)
+.addSearch('cvss_from', 8)
 .toString();
 
 export const LATEST_VULNERABILITIES_FETCH_URL = urijs(`${BASE_URL}${VULN_CVES}`)

--- a/src/SmartComponents/Cards/VulnerabilityCard.js
+++ b/src/SmartComponents/Cards/VulnerabilityCard.js
@@ -51,7 +51,7 @@ class VulnerabilityCard extends Component {
                             <ExclamationCircleIcon className='ins-c-summary__icon ins-c-summary__icon-critical' />
                             <span className='ins-c-summary__emphasis'>{ criticalVulnerabilities.meta.total_items }</span>
                             <span className='ins-c-summary__label'>
-                                <a href={ `/${UI_BASE}/vulnerability/` }>CVEs with CVSS Score &gt;= 7</a>
+                                <a href={ `/${UI_BASE}/vulnerability/cves?cvss_filter=from8to10` }>CVEs with CVSS Score &gt;= 8</a>
                             </span>
                         </div>
                     ) } { criticalVulnerabilitiesFetchStatus === 'pending' && (<Loading />) }


### PR DESCRIPTION
Two things here:
* The CVSS number is incresed from 7 to 8. Vulnerability UI has predefined ranges on CVSS_Filter as there is no PF4 slider yet and if we want to redirect the user to filtered table, it needs to match predefined ranges. It was agreed to have a range "8 - 10".

* This is more a temporal parameter until the variable cvvs range gets resolved. However at least the user is now redirected to filtered list. 