### PR TITLE
Truncate Compliance score to integer

### DIFF
--- a/src/SmartComponents/Cards/ComplianceCard.js
+++ b/src/SmartComponents/Cards/ComplianceCard.js
@@ -69,10 +69,10 @@ class ComplianceCard extends Component {
                                             <Split gutter='md' key={ element.id }>
                                                 <SplitItem className='ins-c-gauge pf-u-text-align-center'>
                                                     <div className='ins-c-gauge__metrics-percentage'>
-                                                        { element.attributes.score * 100 }%
+                                                        { Math.trunc(element.attributes.score * 100) }%
                                                     </div>
                                                     <Gauge label={ element.attributes.name }
-                                                        value={ element.attributes.score * 100 } width={ 82 } height={ 82 }
+                                                        value={ Math.trunc(element.attributes.score * 100) } width={ 82 } height={ 82 }
                                                         timeframe='30'
                                                         identifier={ `compliance-gauge-${ element.id }` } />
                                                 </SplitItem>


### PR DESCRIPTION
Refs: https://projects.engineering.redhat.com/browse/RHCLOUD-1465

![RHELbundleComplianceDashbDonut](https://user-images.githubusercontent.com/598891/58820135-13c9f480-8632-11e9-9e42-58e4b86c82e1.png)

Currently, periodic decimals are shown, which force the numbers to show up outside of the donut chart.