### PR TITLE
Scope styles to cards, use PF vars when needed

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2,26 +2,24 @@
 @import '~@red-hat-insights/insights-frontend-components/Utilities/_all';
 @import '~@red-hat-insights/insights-frontend-components/index.css';
 @import '~@red-hat-insights/insights-frontend-components/Utilities/_mixins';
-@import '@patternfly/patternfly/sass-utilities/colors.scss';
-@import '~@patternfly/patternfly/sass-utilities/scss-variables.scss';
 
 .pf-l-page__main .pf-c-card { min-height: 100%; }
 
 .ins-c-summary {
-    &__accent { color: $pf-color-black-500; }
+    &__accent { color: var(--pf-global--palette--black-500); }
 
     &__emphasis { @include rem("font-size", 32px); }
 
     &__icon {
-        &-critical { fill: $pf-color-red-100; }
-        &-high { fill: $pf-color-orange-300; }
-        &-medium { fill: $pf-color-gold-300; }
-        &-low { fill: $pf-color-blue-300; }
+        &-critical { fill: var(--pf-global--palette--red-100); }
+        &-high { fill: var(--pf-global--palette--orange-300); }
+        &-medium { fill: var(--pf-global--palette--gold-300); }
+        &-low { fill: var(--pf-global--palette--blue-300); }
 
-        &-flag { fill: $pf-color-blue-500; }
-        &-check { fill: $pf-color-green-300; }
+        &-flag { fill: var(--pf-global--palette--blue-500); }
+        &-check { fill: var(--pf-global--palette--green-300); }
 
-        &-info { fill: $pf-color-blue-200; }
+        &-info { fill: var(--pf-global--palette--blue-200); }
     }
 
     &__title { @include rem("margin-bottom", 10px); }
@@ -31,9 +29,9 @@
         @include rem("margin-right", 10px);
     }
 
-    .ins-m-green { color: $pf-color-green-400; }
+    .ins-m-green { color: var(--pf-global--palette--green-400); }
 
-    .ins-m-red { color: $pf-color-red-100; }
+    .ins-m-red { color: var(--pf-global--palette--red-100); }
 }
 
 // ==================================================================

--- a/src/SmartComponents/Advisor/_Advisor.scss
+++ b/src/SmartComponents/Advisor/_Advisor.scss
@@ -1,12 +1,14 @@
-.pf-c-chart {
-  top: 0;
-}
+.ins-c-dashboard__card--Advisor {
+  .pf-c-chart {
+    top: 0;
+  }
 
-.stackChartLegend {
-  left: -9px;
-  position: relative;
-}
+  .stackChartLegend {
+    left: -9px;
+    position: relative;
+  }
 
-a {
-  font-size: small;
+  a {
+    font-size: small;
+  }
 }


### PR DESCRIPTION
## What
There were some rogue styles affecting the left nav. Since we can still affect chroming styles, we need to scope the styles correctly. Also, remove the PF sass imports for regular ol css vars.

If we did wan to scope the font-size for `a` to everything in the dashboard, we should scope it to the main area so we still don't affect chrome.

## Screenshots

### Before
<img width="1680" alt="Screen Shot 2020-03-19 at 11 35 20 AM" src="https://user-images.githubusercontent.com/12520842/77084862-e2aa8d00-69d5-11ea-8960-4be7d410dfab.png">

### After
<img width="1680" alt="Screen Shot 2020-03-19 at 11 35 08 AM" src="https://user-images.githubusercontent.com/12520842/77084877-e63e1400-69d5-11ea-9009-4bc5e0e88896.png">
