### PR TITLE
fix esi tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta charset="UTF-8">
         <title>Dashboard</title>
-        <esi:include src="@@env/chrome/snippets/head.html"/>
+        <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>
-        <esi:include src="@@env/chrome/snippets/body.html"/>
+        <esi:include src="/@@env/chrome/snippets/body.html"/>
     </body>
 </html>


### PR DESCRIPTION
The `@@env` tag needs a slash before it after we updated the config, but I missed it.