### PR TITLE
make empty state bodies small text

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -50,3 +50,8 @@
 
     }
 }
+
+// Empty states
+.page__dashboard .pf-c-empty-state__body {
+    font-size: var(--pf-global--FontSize--sm);
+}

--- a/src/SmartComponents/Compliance/ComplianceCard.scss
+++ b/src/SmartComponents/Compliance/ComplianceCard.scss
@@ -8,10 +8,7 @@
     &.pf-c-empty-state {
       padding: 0;
     }
-  
-    .pf-c-empty-state__body {
-      font-size: var(--pf-global--FontSize--sm);
-    }
+
   
     .pf-c-empty-state__secondary {
       margin-top: var(--pf-global--spacer--md);


### PR DESCRIPTION
## Prerequisites

- [x] Scope your styles to your individual card

## What

Empty state bodies should be `--pf-global--FontSize--sm` size

This makes remediations empty state body smaller and moves the compliance style to the app level

## Screenshots

### Before
![Screen Shot 2020-04-15 at 9 04 11 AM](https://user-images.githubusercontent.com/12520842/79340300-17880200-7ef8-11ea-899f-681ee9a52677.png)


### After
![Screen Shot 2020-04-15 at 9 02 41 AM](https://user-images.githubusercontent.com/12520842/79340156-e4de0980-7ef7-11ea-8248-32462b595e77.png)


## Additional Info
[if needed]

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
