### PR TITLE
fix subscriptions utilized link and tooltip hover area

### DIFF
--- a/src/SmartComponents/SubscriptionsUtilized/Constants.js
+++ b/src/SmartComponents/SubscriptionsUtilized/Constants.js
@@ -16,3 +16,9 @@ export const RHSM_API_PRODUCT_ID_TYPES = {
 export const RHSM_API_QUERY_GRANULARITY_TYPES = {
     DAILY: 'daily'
 };
+
+export const SW_PATHS = {
+    APP: '/subscriptions',
+    RHEL: '/subscriptions/rhel-sw',
+    OPENSHIFT: '/subscriptions/openshift-sw'
+};

--- a/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.scss
+++ b/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.scss
@@ -3,6 +3,15 @@
   padding-left: 0;
 }
 
+.ins-c-subscriptions-utilized__chart-link {
+  padding-left: 0;
+  padding-right: 0;
+
+  .pf-c-progress {
+    color: inherit;
+  }
+}
+
 .ins-c-subscriptions-utilized__empty-state {
   &.pf-c-empty-state {
     padding: 0;


### PR DESCRIPTION
## Prerequisites

- [ ] Scope your styles to your individual card
- [x] You are using translations when necessary with proper plural/singular modifications
- [x] You are using the template card provided
- [x] Use functional components & hooks (please)
- [x] Attach screenshots (before and after)
- [x] Make sure that all text in blue is populated with the correct link. If you're unsure what the url should be, just ask!

## What
- Applies a product link button towards the Subscription Watch GUI for both RHEL and OpenShift
- Expand tooltips hover area with the button used for the aforementioned "link"
- Cleans up the productsHaveData and instead now uses a length check for "products having data" to account for displaying the pending state fully

## Screenshots

### Before
  
![Screen Shot 2020-04-24 at 11 54 37 AM](https://user-images.githubusercontent.com/3761375/80232521-0ab78c80-8623-11ea-81be-4379714f4f81.png)


### After
![Screen Shot 2020-04-24 at 11 33 09 AM](https://user-images.githubusercontent.com/3761375/80232538-11460400-8623-11ea-9c25-2a9bd43e2c6b.png)

 
![Apr-24-2020 11-34-59](https://user-images.githubusercontent.com/3761375/80232571-202cb680-8623-11ea-94a9-df19cfe88591.gif)



## Additional Info
- Relates https://github.com/RedHatInsights/curiosity-frontend/issues/266
- It appears the text decoration on the links is being overridden "on hover", however this appears consistent with behavior that happens on this link as well...
![Screen Shot 2020-04-24 at 11 54 37 AM copy](https://user-images.githubusercontent.com/3761375/80232753-6550e880-8623-11ea-8028-0bb2ab38ca9e.png)


## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker

closes #130 