### PR TITLE
make sure permissions exist before loading stuff

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,19 +37,22 @@ const App = (props) => {
         // TODO: Update this function to query multiple apps instead of empty request (limited by API)
         insights.chrome.getUserPermissions().then(
             dashboardPermissions => {
-                const permissionList = dashboardPermissions.map(permissions => permissions.permission);
-                setPermissions({
-                    customPolicies: permissionList.includes('custom-policies:*:*'),
-                    compliance: permissionList.includes('compliance:*:*'),
-                    drift: permissionList.includes('drift:*:*'),
-                    advisor: permissionList.includes('insights:*:*'),
-                    remediations: permissionList.includes('remediations:*:*') ||
-                        permissionList.includes('remediations:remediation:*') ||
-                        permissionList.includes('remediations:remediation:read') ||
-                        permissionList.includes('remediations:*:read'),
-                    patch: permissionList.includes('patch:*:*'),
-                    vulnerability: permissionList.includes('vulnerability:*:*')
-                });
+                const permissionList = dashboardPermissions.length && dashboardPermissions.map(permissions => permissions.permission);
+                if (permissionList.length) {
+                    setPermissions({
+                        customPolicies: permissionList.includes('custom-policies:*:*'),
+                        compliance: permissionList.includes('compliance:*:*'),
+                        drift: permissionList.includes('drift:*:*'),
+                        advisor: permissionList.includes('insights:*:*'),
+                        remediations: permissionList.includes('remediations:*:*') ||
+                            permissionList.includes('remediations:remediation:*') ||
+                            permissionList.includes('remediations:remediation:read') ||
+                            permissionList.includes('remediations:*:read'),
+                        patch: permissionList.includes('patch:*:*'),
+                        vulnerability: permissionList.includes('vulnerability:*:*')
+                    });
+                }
+
                 setArePermissionReady(true);
             }
         );


### PR DESCRIPTION
## What

When App.js loaded, if a user didn't have any permissions, there was no way you can map over an undefined object and check to see if it includes anything.

This skips that check and just uses the default `false` value if nothing is returned.

