### PR TITLE
Adjusts stack chart color, tooltip position

### DIFF
--- a/src/ChartTemplates/StackChart/StackChartTemplate.js
+++ b/src/ChartTemplates/StackChart/StackChartTemplate.js
@@ -4,7 +4,7 @@ import './_StackChartTemplate.scss';
 import { Chart, ChartAxis, ChartBar, ChartLegend, ChartStack, ChartTooltip } from '@patternfly/react-charts';
 import {
     c_button_m_control_active_after_BorderBottomColor,
-    global_palette_gold_300,
+    global_palette_gold_200,
     global_palette_gold_400,
     global_palette_orange_300,
     global_palette_red_200
@@ -20,11 +20,11 @@ export const StackChart = ({ ...props }) => {
         global_palette_red_200.value,
         global_palette_orange_300.value,
         global_palette_gold_400.value,
-        global_palette_gold_300.value
+        global_palette_gold_200.value
     ];
     const barWidth = 25;
     const chartLegendFontSize = 12;
-    const labelComponent = () => <ChartTooltip text={ ({ datum }) => `${capitalize(datum.name)}: ${datum.y}` } constrainToVisibleArea />;
+    const labelComponent = () => <ChartTooltip  dx={ -30 } orientation='top' text={ ({ datum }) => `${capitalize(datum.name)}: ${datum.y}` } />;
     const legendData = props.data.map(item => ({ name: `${item.y} ${capitalize(item.name)}`, symbol: { type: null } }));
     const stackChartPadding = { bottom: 0, left: 0, right: 0, top: 0 };
 


### PR DESCRIPTION
addresses    https://github.com/RedHatInsights/insights-dashboard/issues/137#issuecomment-620217448 

addresses     https://github.com/RedHatInsights/insights-dashboard/issues/137#issuecomment-620229864


#### looks like
<img width="1266" alt="Screen Shot 2020-05-04 at 12 55 13 PM" src="https://user-images.githubusercontent.com/6640236/80992210-2d0d8f00-8e07-11ea-99dc-88c9d827949d.png">
<img width="1276" alt="Screen Shot 2020-05-04 at 12 55 01 PM" src="https://user-images.githubusercontent.com/6640236/80992213-2e3ebc00-8e07-11ea-9d2d-26b05d78c405.png">
