### PR TITLE
Compliance: Fetch reports with results

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -6,7 +6,7 @@ export const UI_BASE = './insights';
 
 // Compliance App Constants
 export const COMPLIANCE_FETCH = 'COMPLIANCE_SUMMARY_FETCH';
-export const COMPLIANCE_FETCH_URL = `${BASE_URL}/compliance/profiles`;
+export const COMPLIANCE_FETCH_URL = `${BASE_URL}/compliance/profiles?search=has_test_results=true`;
 
 // Vulnerability App Constants
 const VULN_CVES = '/vulnerability/v1/report/executive';

--- a/src/SmartComponents/Compliance/ComplianceCard.js
+++ b/src/SmartComponents/Compliance/ComplianceCard.js
@@ -69,16 +69,21 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                     {complianceFetchStatus === 'fulfilled' &&
                         (Array.isArray(complianceSummary.data) &&
                             (complianceSummary.data.length > 0 ? <React.Fragment>
-                                {getTopThreePolicies(complianceSummary).map((element, index) =>
+                                {getTopThreePolicies(complianceSummary).map((policy, index) =>
                                     <div className="ins-c-compliance__row" key={ index }>
                                         <div className="ins-c-compliance__row-item">
                                             <PieChart
-                                                ariaDesc="Operating systems used"
-                                                ariaTitle="Pie chart operating systems"
+                                                ariaDesc="Compliance score"
+                                                ariaTitle="Pie chart compliance"
                                                 constrainToVisibleArea={ true }
                                                 data={ [
-                                                    { x: element.attributes.name, y: element.attributes.score },
-                                                    { x: 'empty', y: 100 }
+                                                    {
+                                                        x: 'Compliant',
+                                                        y: policy.attributes.compliant_host_count
+                                                    }, {
+                                                        x: 'Non-compliant',
+                                                        y: policy.attributes.total_host_count - policy.attributes.compliant_host_count
+                                                    }
                                                 ] }
                                                 labels={ ({ datum }) => `${datum.x}: ${datum.y}` }
                                                 padding={ pieChartPadding }
@@ -93,23 +98,25 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                                                     <Button
                                                         className="ins-c-compliance__policy-link"
                                                         component="a"
-                                                        href={ `/${UI_BASE}/compliance/policies/` }
+                                                        href={ `/${UI_BASE}/compliance/reports/${policy.id}` }
                                                         variant="link"
                                                         isInline
                                                     >
-                                                        {element.attributes.name}
+                                                        {policy.attributes.name}
                                                     </Button>
                                                 </StackItem>
                                                 <StackItem>
                                                     <Split gutter='sm'>
                                                         <SplitItem>
                                                             {intl.formatMessage(messages.compliantHostCount,
-                                                                { count: element.attributes.compliant_host_count }
+                                                                { count: policy.attributes.total_host_count }
                                                             )}
                                                         </SplitItem>
                                                         <SplitItem>
                                                             {intl.formatMessage(messages.compliantScore,
-                                                                { score: Math.trunc(element.attributes.score) }
+                                                                { score: Math.trunc(
+                                                                    policy.attributes.compliant_host_count / policy.attributes.total_host_count
+                                                                ) }
                                                             )}
                                                         </SplitItem>
                                                     </Split>
@@ -125,13 +132,13 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                                         <Button
                                             className="ins-c-compliance__policy-link"
                                             component="a"
-                                            href={ `/${UI_BASE}/compliance/policies/` }
+                                            href={ `/${UI_BASE}/compliance/reports/` }
                                             variant="link"
                                             isInline
                                         >
                                             {complianceFetchStatus === 'fulfilled' && Array.isArray(complianceSummary.data) &&
-                                                complianceSummary.data.length > 1 &&
-                                                    `${complianceSummary.data.length} more compliance policies`
+                                                3 - complianceSummary.data.length >= 1 &&
+                                                    `${3 - complianceSummary.data.length} more compliance reports`
                                             }
                                         </Button>
                                     </div>
@@ -148,7 +155,7 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                                     <EmptyStateSecondaryActions>
                                         <Button
                                             variant='link'
-                                            href={ `${UI_BASE}/compliance/policies/` }
+                                            href={ `${UI_BASE}/compliance/reports/` }
                                             component='a'
                                         >
                                             {intl.formatMessage(messages.complianceEmptyStateAction1)}


### PR DESCRIPTION
## What

This makes it fetch only reports which have at least one result. In
addition to that, it fixes a few other things that are outdated since
summit:

 * Aria attributes were wrong
 * Chart was showing the compliant vs non-compliant wrong
 * Link to each report or more policies was wrong
 * 'More reports' link is only shown if there are 4 or more.

## Screenshots

### Before

![ezgif-6-dd55b283f897](https://user-images.githubusercontent.com/598891/82559491-0756e880-9b70-11ea-96cb-480e5189e1d1.gif)

### After

![ezgif-6-60f4f9d4ccd1](https://user-images.githubusercontent.com/598891/82559559-23f32080-9b70-11ea-8c77-d3b42046db5e.gif)




## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
