### PR TITLE
update subscriptions utilized card, apply error code for opt-in

### DIFF
--- a/src/SmartComponents/SubscriptionsUtilized/Constants.js
+++ b/src/SmartComponents/SubscriptionsUtilized/Constants.js
@@ -8,6 +8,16 @@ export const RHSM_API_RESPONSE_DATA_TYPES = {
     HAS_INFINITE: 'has_infinite_quantity'
 };
 
+export const RHSM_API_RESPONSE_ERROR_DATA = 'errors';
+
+export const RHSM_API_RESPONSE_ERROR_DATA_TYPES = {
+    CODE: 'code'
+};
+
+export const RHSM_API_RESPONSE_ERROR_DATA_CODE_TYPES = {
+    OPTIN: 'SUBSCRIPTIONS1004'
+};
+
 export const RHSM_API_PRODUCT_ID_TYPES = {
     RHEL: 'RHEL',
     OPENSHIFT: 'OpenShift Container Platform'

--- a/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.js
+++ b/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.js
@@ -18,6 +18,9 @@ import { setRangedDateTime, filterChartData } from './SubscriptionsUtilizedHelpe
 import {
     RHSM_API_RESPONSE_DATA,
     RHSM_API_RESPONSE_DATA_TYPES,
+    RHSM_API_RESPONSE_ERROR_DATA,
+    RHSM_API_RESPONSE_ERROR_DATA_TYPES,
+    RHSM_API_RESPONSE_ERROR_DATA_CODE_TYPES,
     RHSM_API_PRODUCT_ID_TYPES,
     RHSM_API_QUERY_GRANULARITY_TYPES,
     SW_PATHS
@@ -70,8 +73,12 @@ const SubscriptionsUtilizedCard = ({ subscriptionsUtilizedProductOne, subscripti
         }
 
         if (subscriptionsUtilizedProductOneFetchStatus === 'rejected' && subscriptionsUtilizedProductTwoFetchStatus === 'rejected') {
+            const [productOneError = {}] = subscriptionsUtilizedProductOne.data?.[RHSM_API_RESPONSE_ERROR_DATA] || [];
+            const [productTwoError = {}] = subscriptionsUtilizedProductOne.data?.[RHSM_API_RESPONSE_ERROR_DATA] || [];
+
             chartData.productError = true;
-            chartData.productOptIn = subscriptionsUtilizedProductOne.status === 403 && subscriptionsUtilizedProductTwo.status === 403;
+            chartData.productOptIn = productOneError[RHSM_API_RESPONSE_ERROR_DATA_TYPES.CODE] === RHSM_API_RESPONSE_ERROR_DATA_CODE_TYPES.OPTIN &&
+                productTwoError[RHSM_API_RESPONSE_ERROR_DATA_TYPES.CODE] === RHSM_API_RESPONSE_ERROR_DATA_CODE_TYPES.OPTIN;
         }
 
         setProducts(chartData);


### PR DESCRIPTION
## Prerequisites

- ~Scope your styles to your individual card~
- ~You are using translations when necessary with proper plural/singular modifications~
- [x] You are using the template card provided
- [x] Use functional components & hooks (please)
- ~Attach screenshots (before and after)~
- ~Make sure that all text in blue is populated with the correct link. If you're unsure what the url should be, just ask!~

## What

This applies the RHSM Tally and Capacity error code check to determine if a 403 is actually "opt-in" instead of a generic 403 status check.

## Screenshots
Behind the scenes error code work. The before and after should visually be the exact same.

## Additional Info
Directly relates to RHSM API changes
- [Curiosity/Subs Watch issue 281](https://github.com/RedHatInsights/curiosity-frontend/issues/281)

And segues into user permissions, RBAC
- [Curiosity/Subs Watch issue 300](https://github.com/RedHatInsights/curiosity-frontend/issues/300)

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
