### PR TITLE
use per_page=1 for inventory to speed up calls

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -42,14 +42,15 @@ export const SUBSCRIPTIONS_UTILIZED_CAPACITY_FETCH_URL = `${BASE_URL}/rhsm-subsc
 
 // Inventory Constants
 export const INVENTORY_BASE = '/inventory/v1';
+const INVENTORY_PER_PAGE = 'per_page=1';
 export const INVENTORY_TOTAL_FETCH = 'INVENTORY_TOTAL_FETCH';
-export const INVENTORY_TOTAL_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts`;
+export const INVENTORY_TOTAL_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?${INVENTORY_PER_PAGE}`;
 export const INVENTORY_FETCH = 'INVENTORY_FETCH';
-export const INVENTORY_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?registered_with=insights`;
+export const INVENTORY_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?registered_with=insights&${INVENTORY_PER_PAGE}`;
 export const INVENTORY_STALE_FETCH = 'INVENTORY_STALE_FETCH';
-export const INVENTORY_STALE_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?staleness=stale&registered_with=insights`;
+export const INVENTORY_STALE_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?staleness=stale&registered_with=insights&${INVENTORY_PER_PAGE}`;
 export const INVENTORY_WARNING_FETCH = 'INVENTORY_WARNING_FETCH';
-export const INVENTORY_WARNING_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?staleness=stale_warning&registered_with=insights`;
+export const INVENTORY_WARNING_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?staleness=stale_warning&registered_with=insights&${INVENTORY_PER_PAGE}`;
 
 // Remediations App Constants
 const REMEDIATIONS_BASE = '/remediations/v1';


### PR DESCRIPTION
## What

Speed up inventory API calls by only using per_page=1, this will be updated in the future when `0` is supported. All we need is the metadata, no actual hosts.

## Screenshots
nothing changed

