### PR TITLE
Fix StackChart Tooltip size

### DIFF
--- a/src/ChartTemplates/StackChart/_StackChartTemplate.scss
+++ b/src/ChartTemplates/StackChart/_StackChartTemplate.scss
@@ -3,8 +3,10 @@
     position: relative;
 }
 
-.pf-c-chart {
-    height: unset !important;
+.ins-c-stack-chart {
+    height: 40px;
+    width: 525px;
+    margin: 10px 0 10px 0;
 }
 
 .visually-hidden {

--- a/src/SmartComponents/Advisor/Advisor.js
+++ b/src/SmartComponents/Advisor/Advisor.js
@@ -65,11 +65,11 @@ const Advisor = ({ recStats, recStatsStatus, advisorFetchStatsRecs, advisorFetch
                         ariaDesc={ intl.formatMessage(messages.advisorChartDescription) }
                         ariaTitle="Advisor recommendations chart"
                         height={ 40 }
-                        width={ 500 }
                         maxWidth={ 500 }
                         legendHeight={ 36 }
                         legendWidth={ 500 }
                         data={ chartData }
+                        constrainToVisibleArea={ false }
                         legendClick={ legendClick }
                     />
                 }

--- a/src/SmartComponents/Vulnerability/VulnerabilityCard.js
+++ b/src/SmartComponents/Vulnerability/VulnerabilityCard.js
@@ -91,11 +91,11 @@ const VulnerabilityCard = ({ fetchVulnerabilities, vulnerabilities, vulnerabilit
                         ariaDesc={ intl.formatMessage(messages.cvesImpactingSystems, { cves: vulnerabilities.cves_total }) }
                         ariaTitle="Vulnerabilities chart"
                         height={ 40 }
-                        width={ 500 }
                         maxWidth={ 500 }
                         legendHeight={ 36 }
                         legendWidth={ 500 }
                         data={ chartData }
+                        constrainToVisibleArea={ false }
                         legendData={ stackChartLegendData }
                         legendClick={ legendClick }
                     />


### PR DESCRIPTION
## Prerequisites

- [x] Scope your styles to your individual card
- [x] You are using translations when necessary with proper plural/singular modifications
- [x] You are using the template card provided
- [x] Use functional components & hooks (please)
- [x] Attach screenshots (before and after)
- [x] Make sure that all text in blue is populated with the correct link. If you're unsure what the url should be, just ask!

## What

In response to [RHCLOUD-8045](https://projects.engineering.redhat.com/browse/RHCLOUD-8045), this PR adds a window listener to correct the size of the tooltips.

## Screenshots

### Before
Currently, we have a scalable chart.

<img width="1440" alt="Screen Shot 2020-07-24 at 8 33 50 AM" src="https://user-images.githubusercontent.com/4829473/88391588-7925fb00-cd88-11ea-8255-6b9060f7a17f.png">

### After

<img width="1440" alt="Screen Shot 2020-07-29 at 11 34 37 AM" src="https://user-images.githubusercontent.com/4829473/88820651-96473900-d18f-11ea-9f22-2b31730c223e.png">

<img width="1440" alt="Screen Shot 2020-07-29 at 11 34 56 AM" src="https://user-images.githubusercontent.com/4829473/88820653-97786600-d18f-11ea-9c9a-8b879056dd05.png">

<img width="982" alt="Screen Shot 2020-07-29 at 11 35 09 AM" src="https://user-images.githubusercontent.com/4829473/88820661-9810fc80-d18f-11ea-8d67-ca3290a69915.png">

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
