### PR TITLE
Add Tooltip for longer remediation names

### DIFF
--- a/src/SmartComponents/Remediations/RunStatus.js
+++ b/src/SmartComponents/Remediations/RunStatus.js
@@ -12,6 +12,7 @@ import QuestionIcon from './../../Icons/QuestionIcon';
 import { REMEDIATIONS_PLAYBOOK_RUNS_FETCH_URL } from '../../AppConstants';
 import TimeStamp from './../../PresentationalComponents/TimeStamp/TimeStamp';
 import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 
@@ -91,9 +92,14 @@ const RunStatus = ({ id, name, index }) => {
             }
         </div>
         <div className="ins-c-remediation__timestamp">
-            <Button id={ `remediation-link-${index}` } component="a" variant="link" isInline href={ `./insights/remediations/${id}` }>
-                {name} {/* do not intl this */}
-            </Button>
+            {name.length > 20 ? <Tooltip content={ name }>
+                <Button id={ `remediation-link-${index}` } component="a" variant="link" isInline href={ `./insights/remediations/${id}` }>
+                    {`${name.substring(0, 20)}...`} {/* do not intl this */}
+                </Button>
+            </Tooltip> :
+                <Button id={ `remediation-link-${index}` } component="a" variant="link" isInline href={ `./insights/remediations/${id}` }>
+                    {name} {/* do not intl this */}
+                </Button>}
             { loaded === undefined && <Skeleton size='md' /> }
             { loaded && hasData
                 ? <TimeStamp timestamp={ <DateFormat type='exact' date={ playbookRun[0].created_at } /> } />


### PR DESCRIPTION
## Prerequisites

- [x] Scope your styles to your individual card
- [x] You are using translations when necessary with proper plural/singular modifications
- [x] You are using the template card provided
- [x] Use functional components & hooks (please)
- [x] Attach screenshots (before and after)
- [x] Make sure that all text in blue is populated with the correct link. If you're unsure what the url should be, just ask!

## What

This PR adds a Tooltip to a remediation's name (as it appears in the remediations template card) if the length of the name is greater than 20. I chose 20 because it aligns well with the `## more remediations` button length.

## Screenshots

### Before
![Screen Shot 2020-08-03 at 4 22 45 PM](https://user-images.githubusercontent.com/4829473/89224181-0a297d00-d5a6-11ea-9656-5d91136519e4.png)

### After
![Screen Shot 2020-08-03 at 4 21 18 PM](https://user-images.githubusercontent.com/4829473/89224267-2b8a6900-d5a6-11ea-83bb-cfaaa7f67121.png)

![Screen Shot 2020-08-03 at 4 20 07 PM](https://user-images.githubusercontent.com/4829473/89224271-2d542c80-d5a6-11ea-85d9-0c391cec6674.png)

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
