### PR TITLE
Compliance button urls redirect correctly on beta

### DIFF
--- a/src/SmartComponents/Compliance/ComplianceCard.js
+++ b/src/SmartComponents/Compliance/ComplianceCard.js
@@ -87,7 +87,7 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                                             id={ `compliance-link-${index + 1}` }
                                             className="ins-c-compliance__policy-link"
                                             component="a"
-                                            href={ `/${UI_BASE}/compliance/reports/${policy.id}` }
+                                            href={ `${UI_BASE}/compliance/reports/${policy.id}` }
                                             variant="link"
                                             isInline
                                         >
@@ -121,7 +121,7 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                                     <Button
                                         className="ins-c-compliance__policy-link"
                                         component="a"
-                                        href={ `/${UI_BASE}/compliance/reports/` }
+                                        href={ `${UI_BASE}/compliance/reports/` }
                                         variant="link"
                                         isInline
                                     >


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHICOMPL-755

that leading slash leads to the beta location gettin eaten up