### PR TITLE
fix(Patch PieChart): pie chart legend color mistmatch

### DIFF
--- a/src/SmartComponents/PatchManager/PatchManagerCard.js
+++ b/src/SmartComponents/PatchManager/PatchManagerCard.js
@@ -36,8 +36,8 @@ const PatchManagerCard = ({ systems, systemsStatus, fetchSystems, fetchSecurity,
 
     const pieChartData = [
         { x: intl.formatMessage(messages.securityAdvisories, { count: security }), y: security, fill: chart_color_blue_400.value },
-        { x: intl.formatMessage(messages.bugfixAdvisories, { count: bugs }), y: bugs, fill: chart_color_blue_200.value },
-        { x: intl.formatMessage(messages.enhancementAdvisories, { count: enhancements }), y: enhancements, fill: chart_color_blue_300.value }
+        { x: intl.formatMessage(messages.bugfixAdvisories, { count: bugs }), y: bugs, fill: chart_color_blue_300.value },
+        { x: intl.formatMessage(messages.enhancementAdvisories, { count: enhancements }), y: enhancements, fill: chart_color_blue_200.value }
     ];
     const pieChartLegendData = pieChartData.map(item => ({ name: `${item.y} ${item.x}`, symbol: { fill: `${item.fill}`, type: 'circle' } }));
     const pieChartPadding = { bottom: 0, left: 0, right: 0, top: 0 };


### PR DESCRIPTION
#124  What

Patchman Pie chart legend colour mismatch is fixed. 

## Screenshots

### Before
[before screenshot]
![image](https://user-images.githubusercontent.com/59481011/89994095-f3f77d00-dc87-11ea-9fdb-b82fee9fdbc7.png)


### After
[after screenshot]
![image](https://user-images.githubusercontent.com/59481011/89994006-d2969100-dc87-11ea-970c-8916eebc0d24.png)

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
