### PR TITLE
Adds global filter support to dashboard and advisor card 🤗🍍🐞

### DIFF
--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -92,3 +92,8 @@ export const fetchRemediations = (options) => ({
     type: ActionTypes.REMEDIATIONS_FETCH,
     payload: fetchData(ActionTypes.REMEDIATIONS_FETCH_URL, {}, options)
 });
+
+export const setSelectedTags = (tags) => ({
+    type: ActionTypes.SELECTED_TAGS_SET,
+    payload: tags
+});

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -3,6 +3,7 @@ import * as urijs from 'urijs';
 
 const BASE_URL = '/api';
 export const UI_BASE = './insights';
+export const SELECTED_TAGS_SET = 'SELECTED_TAGS_SET';
 
 // Compliance App Constants
 export const COMPLIANCE_FETCH = 'COMPLIANCE_SUMMARY_FETCH';

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -26,7 +26,6 @@ const initialState = Immutable({
     subscriptionsUtilizedProductOneFetchStatus: '',
     subscriptionsUtilizedProductTwo: [],
     subscriptionsUtilizedProductTwoFetchStatus: '',
-
     inventorySummary: {},
     inventoryFetchStatus: '',
     inventoryStaleSummary: {},
@@ -36,11 +35,18 @@ const initialState = Immutable({
     inventoryTotalSummary: {},
     inventoryTotalFetchStatus: '',
     remediations: {},
-    remediationsFetchStatus: ''
+    remediationsFetchStatus: '',
+    selectedTags: []
 });
 
 export const DashboardStore = (state = initialState, action) => {
     switch (action.type) {
+        // GLOBAL
+        case ActionTypes.SELECTED_TAGS_SET:
+            return Immutable.merge(state, {
+                selectedTags: action.payload
+            });
+
         // COMPLIANCE
         case `${ActionTypes.COMPLIANCE_FETCH}_PENDING`:
             return state.set('complianceFetchStatus', 'pending');
@@ -170,9 +176,6 @@ export const DashboardStore = (state = initialState, action) => {
                 subscriptionsUtilizedProductTwoFetchStatus: 'rejected'
             });
 
-        default:
-            return state;
-
         // Inventory
         case `${ActionTypes.INVENTORY_FETCH}_PENDING`:
             return state.set('inventoryFetchStatus', 'pending');
@@ -224,5 +227,9 @@ export const DashboardStore = (state = initialState, action) => {
             });
         case `${ActionTypes.REMEDIATIONS_FETCH}_REJECTED`:
             return state.set('remediationsFetchStatus', 'rejected');
+
+        default:
+            return state;
+
     }
 };

--- a/src/SmartComponents/Advisor/Advisor.js
+++ b/src/SmartComponents/Advisor/Advisor.js
@@ -20,16 +20,16 @@ import { useIntl } from 'react-intl';
  * Advisor Card for showing count/severity of rec hits
  */
 const Advisor = ({ recStats, recStatsStatus, advisorFetchStatsRecs, advisorFetchStatsSystems,
-    advisorIncidents, advisorIncidentsStatus, advisorFetchIncidents, systemsStats, systemsStatsStatus }) => {
+    advisorIncidents, advisorIncidentsStatus, advisorFetchIncidents, systemsStats, systemsStatsStatus, selectedTags }) => {
 
     const intl = useIntl();
     const [chartData, setChartData] = useState([]);
 
     useEffect(() => {
-        advisorFetchStatsRecs();
-        advisorFetchStatsSystems();
-        advisorFetchIncidents();
-    }, [advisorFetchIncidents, advisorFetchStatsRecs, advisorFetchStatsSystems]);
+        advisorFetchStatsRecs(selectedTags.length && ({ tags: selectedTags.join() }));
+        advisorFetchStatsSystems(selectedTags.length && ({ tags: selectedTags.join() }));
+        advisorFetchIncidents(selectedTags.length && ({ tags: selectedTags.join() }));
+    }, [advisorFetchIncidents, advisorFetchStatsRecs, advisorFetchStatsSystems, selectedTags]);
 
     useEffect(() => {
         recStatsStatus === 'fulfilled' && setChartData([
@@ -42,7 +42,8 @@ const Advisor = ({ recStats, recStatsStatus, advisorFetchStatsRecs, advisorFetch
 
     const legendClick = chartData.map((data) => {
         const risk = data.name.toLowerCase();
-        return `${UI_BASE}/advisor/recommendations?total_risk=${SEVERITY_MAP[risk]}&reports_shown=true&impacting=true&offset=0&limit=10`;
+        // eslint-disable-next-line max-len
+        return `${UI_BASE}/advisor/recommendations?total_risk=${SEVERITY_MAP[risk]}&reports_shown=true&impacting=true&offset=0&limit=10${selectedTags.length && '&tags=' + selectedTags.join()}`;
     });
 
     return <TemplateCard appName='Advisor' data-ouia-safe>
@@ -92,7 +93,8 @@ Advisor.propTypes = {
     systemsStatsStatus: PropTypes.string,
     advisorIncidents: PropTypes.object,
     advisorIncidentsStatus: PropTypes.string,
-    advisorFetchIncidents: PropTypes.func
+    advisorFetchIncidents: PropTypes.func,
+    selectedTags: PropTypes.array
 };
 
 export default connect(
@@ -102,11 +104,12 @@ export default connect(
         systemsStats: DashboardStore.advisorStatsSystems,
         systemsStatsStatus: DashboardStore.advisorStatsSystemsStatus,
         advisorIncidents: DashboardStore.advisorIncidents,
-        advisorIncidentsStatus: DashboardStore.advisorIncidentsStatus
+        advisorIncidentsStatus: DashboardStore.advisorIncidentsStatus,
+        selectedTags: DashboardStore.selectedTags
     }),
     dispatch => ({
-        advisorFetchStatsRecs: (url) => dispatch(AppActions.advisorFetchStatsRecs(url)),
-        advisorFetchStatsSystems: (url) => dispatch(AppActions.advisorFetchStatsSystems(url)),
-        advisorFetchIncidents: (url) => dispatch(AppActions.advisorFetchIncidents(url))
+        advisorFetchStatsRecs: (data) => dispatch(AppActions.advisorFetchStatsRecs(data)),
+        advisorFetchStatsSystems: (data) => dispatch(AppActions.advisorFetchStatsSystems(data)),
+        advisorFetchIncidents: (data) => dispatch(AppActions.advisorFetchIncidents(data))
     })
 )(Advisor);

--- a/src/SmartComponents/Advisor/Constants.js
+++ b/src/SmartComponents/Advisor/Constants.js
@@ -1,5 +1,5 @@
-export const INCIDENT_URL = `/advisor/recommendations?reports_shown=undefined&impacting=true&offset=0&limit=10&sort=-publish_date&incident=true`;
-export const NEW_REC_URL = `/advisor/recommendations?reports_shown=undefined&impacting=true&offset=0&limit=10&sort=-publish_date`;
+export const INCIDENT_URL = `/advisor/recommendations?reports_shown=true&impacting=true&offset=0&limit=10&sort=-publish_date&incident=true`;
+export const NEW_REC_URL = `/advisor/recommendations?reports_shown=true&impacting=true&offset=0&limit=10&sort=-publish_date`;
 
 export const SEVERITY_MAP = {
     critical: 4,


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-9044

on filter change, we go into loading screen for the advisor widget then display the results

#### looks like

<img width="1436" alt="Screen Shot 2020-09-09 at 10 11 29 AM" src="https://user-images.githubusercontent.com/6640236/92609690-dc121980-f284-11ea-9e55-aa9e9004cc22.png">
<img width="1437" alt="Screen Shot 2020-09-09 at 10 11 12 AM" src="https://user-images.githubusercontent.com/6640236/92609693-dcaab000-f284-11ea-95b5-59dc11c56d29.png">
<img width="1438" alt="Screen Shot 2020-09-09 at 10 11 01 AM" src="https://user-images.githubusercontent.com/6640236/92609695-dd434680-f284-11ea-8d81-a7c3c7501460.png">
