### PR TITLE
If there are no incidents, advisor incident text is green

### DIFF
--- a/src/SmartComponents/Advisor/Advisor.js
+++ b/src/SmartComponents/Advisor/Advisor.js
@@ -97,15 +97,16 @@ const Advisor = ({ recStats, recStatsStatus, advisorFetchStatsRecs, advisorFetch
     }, [intl, recStats, recStatsStatus]);
 
     return <TemplateCard appName='Advisor' data-ouia-safe>
-        {advisorIncidentsStatus === 'pending' ? <Loading /> : <TemplateCardHeader titleClassName='ins-m-red'
-            title={ `${intl.formatMessage(messages.incidents, { incidents: advisorIncidents?.meta?.count || 0 })}` }>
+        {advisorIncidentsStatus === 'pending' ? <Loading /> :
+            <TemplateCardHeader titleClassName={ advisorIncidents?.meta?.count ? 'ins-m-red' : 'ins-m-green' }
+                title={ `${intl.formatMessage(messages.incidents, { incidents: advisorIncidents?.meta?.count })}` }>
             &nbsp;
-            {intl.formatMessage(messages.inAdvisor)}
+                {intl.formatMessage(messages.inAdvisor)}
             &nbsp;
-            <Button component='a' href={ `${UI_BASE}${INCIDENT_URL}` } variant='link' isInline>
-                {intl.formatMessage(messages.recommendations)}
-            </Button>
-        </TemplateCardHeader>}
+                <Button component='a' href={ `${UI_BASE}${INCIDENT_URL}` } variant='link' isInline>
+                    {intl.formatMessage(messages.recommendations)}
+                </Button>
+            </TemplateCardHeader>}
         {advisorIncidentsStatus === 'rejected' ?
             <TemplateCardBody><FailState appName='Advisor' /></TemplateCardBody>
             : <TemplateCardBody>


### PR DESCRIPTION
also, the count returned is 0, no need for the `|| 0`

#### looks like
<img width="932" alt="Screen Shot 2020-09-17 at 12 21 48 PM" src="https://user-images.githubusercontent.com/6640236/93499450-01d09b80-f8e1-11ea-83a6-a6665e3d177f.png">
