### PR TITLE
Add ternary operator for url creation in advisor card

### DIFF
--- a/src/SmartComponents/Advisor/Advisor.js
+++ b/src/SmartComponents/Advisor/Advisor.js
@@ -42,7 +42,7 @@ const Advisor = ({ recStats, recStatsStatus, advisorFetchStatsRecs, advisorFetch
         global_palette_cyan_300.value,
         global_palette_cyan_400.value
     ];
-    const urlRest = `&reports_shown=true&impacting=true&offset=0&limit=10${selectedTags?.length && `&tags=${selectedTags.join()}`}${workloads?.SAP && `&sap_system=true`}`;
+    const urlRest = `&reports_shown=true&impacting=true&offset=0&limit=10${selectedTags?.length ? `&tags=${selectedTags.join()}` : ''}${workloads?.SAP ? `&sap_system=true` : ''}`;
     const pieLegendClick = categoryData.map(({ value }) => `${UI_BASE}/advisor/recommendations?category=${value}${urlRest}`);
     const totalRiskUrl = (risk) => `${UI_BASE}/advisor/recommendations?total_risk=${risk}${urlRest}`;
 


### PR DESCRIPTION
## Prerequisites

- [x] Scope your styles to your individual card
- [x] You are using translations when necessary with proper plural/singular modifications
- [x] You are using the template card provided
- [x] Use functional components & hooks (please)
- [x] Attach screenshots (before and after)
- [x] Make sure that all text in blue is populated with the correct link. If you're unsure what the url should be, just ask!

## What
This PR fixes https://issues.redhat.com/browse/ADVISOR-1377. We are seeing `NaN` as the pagination limit when navigating from the Advisor dashboard card to the Advisor recommendations page.

## Screenshots

### Before
![Screen Shot 2020-09-29 at 11 23 39 AM](https://user-images.githubusercontent.com/4829473/94579111-73e0a300-0246-11eb-803f-d22e715a6622.png)

### After
![Screen Shot 2020-09-29 at 11 23 17 AM](https://user-images.githubusercontent.com/4829473/94579135-7a6f1a80-0246-11eb-9247-fa56088f1722.png)

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
