### PR TITLE
Pass sap_system and tags to inventory enpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4129,9 +4129,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.2.4.tgz",
-      "integrity": "sha512-Fhc4G8cIQVgwfA7AJCv6ri3tGvmTpjcQbRGelWiCdlkcxn/c4oC4hMnvKdAPr8HFPzug1D9vEP9Ojw/kvhZ7UA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.2.5.tgz",
+      "integrity": "sha512-XvOvnTALiJGHyVftCjTFWofLjeMnO7gb0S3c949QZo8I+07vd7AsEvrps24RoBnO6S6qlAjOhPPxfSvt9Ie6YA==",
       "requires": {
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",
@@ -4172,59 +4172,59 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.24.2.tgz",
-      "integrity": "sha512-P/uZC/VrLRpU7MVEJnlZK5+AkEmuHu+mns5gC91Z4gjn7GamjR/CaXVedHGw/15ZrsQiAiwoWwuxpv4Ypd/+SA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.25.0.tgz",
+      "integrity": "sha512-QDVUbUuTu58xCdId0eUO4YzpvrPdoUw1ryVy/Yep9Es/HD0fiSyO1Js0eQVkV/EdXtyo2pomc1Bpy7dbn2EJ2w==",
       "requires": {
-        "@sentry/core": "5.24.2",
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/core": "5.25.0",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.24.2.tgz",
-      "integrity": "sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.25.0.tgz",
+      "integrity": "sha512-hY6Zmo7t/RV+oZuvXHP6nyAj/QnZr2jW0e7EbL5YKMV8q0vlnjcE0LgqFXme726OJemoLk67z+sQOJic/Ztehg==",
       "requires": {
-        "@sentry/hub": "5.24.2",
-        "@sentry/minimal": "5.24.2",
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/hub": "5.25.0",
+        "@sentry/minimal": "5.25.0",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.24.2.tgz",
-      "integrity": "sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.25.0.tgz",
+      "integrity": "sha512-kOlOiJV8wMX50lYpzMlOXBoH7MNG0Ho4RTusdZnXZBaASq5/ljngDJkLr6uylNjceZQP21wzipCQajsJMYB7EQ==",
       "requires": {
-        "@sentry/types": "5.24.2",
-        "@sentry/utils": "5.24.2",
+        "@sentry/types": "5.25.0",
+        "@sentry/utils": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.24.2.tgz",
-      "integrity": "sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.25.0.tgz",
+      "integrity": "sha512-9JFKuW7U+1vPO86k3+XRtJyooiVZsVOsFFO4GulBzepi3a0ckNyPgyjUY1saLH+cEHx18hu8fGgajvI8ANUF2g==",
       "requires": {
-        "@sentry/hub": "5.24.2",
-        "@sentry/types": "5.24.2",
+        "@sentry/hub": "5.25.0",
+        "@sentry/types": "5.25.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.24.2.tgz",
-      "integrity": "sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ=="
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.25.0.tgz",
+      "integrity": "sha512-8M4PREbcar+15wrtEqcwfcU33SS+2wBSIOd/NrJPXJPTYxi49VypCN1mZBDyWkaK+I+AuQwI3XlRPCfsId3D1A=="
     },
     "@sentry/utils": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.24.2.tgz",
-      "integrity": "sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.25.0.tgz",
+      "integrity": "sha512-Hz5spdIkMSRH5NR1YFOp5qbsY5Ud2lKhEQWlqxcVThMG5YNUc10aYv5ijL19v0YkrC2rqPjCRm7GrVtzOc7bXQ==",
       "requires": {
-        "@sentry/types": "5.24.2",
+        "@sentry/types": "5.25.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@redhat-cloud-services/frontend-components": "2.4.9",
     "@redhat-cloud-services/frontend-components-charts": "2.4.2",
     "@redhat-cloud-services/frontend-components-translations": "2.2.1",
-    "@redhat-cloud-services/frontend-components-utilities": "2.2.4",
+    "@redhat-cloud-services/frontend-components-utilities": "2.2.5",
     "classnames": "2.2.6",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/src/SmartComponents/Advisor/Advisor.js
+++ b/src/SmartComponents/Advisor/Advisor.js
@@ -24,7 +24,7 @@ import Loading from '../../PresentationalComponents/Loading/Loading';
 import { PieChart } from '../../ChartTemplates/PieChart/PieChartTemplate';
 import PropTypes from 'prop-types';
 import { UI_BASE } from '../../AppConstants';
-import { capitalize } from '../../Utilities/Common';
+import { capitalize, workloadsPropType } from '../../Utilities/Common';
 import { connect } from 'react-redux';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
@@ -174,7 +174,7 @@ Advisor.propTypes = {
     advisorIncidentsStatus: PropTypes.string,
     advisorFetchIncidents: PropTypes.func,
     selectedTags: PropTypes.array,
-    workloads: PropTypes.object
+    workloads: workloadsPropType
 };
 
 export default connect(

--- a/src/SmartComponents/SystemInventory/SystemInventoryCard.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryCard.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import './SystemInventoryCard.scss';
 
 import * as AppActions from '../../AppActions';
@@ -6,6 +7,7 @@ import React, { useEffect, Fragment } from 'react';
 import { TemplateCard, TemplateCardBody, TemplateCardHeader } from '../../PresentationalComponents/Template/TemplateCard';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/files/RBACHook';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
+import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
 import FailState from '../../PresentationalComponents/FailState/FailState';
 import { IconInline } from '../../PresentationalComponents/IconInline/IconInline';
@@ -22,7 +24,8 @@ const SystemInventoryCard = ({
     fetchInventory, inventoryFetchStatus, inventorySummary,
     fetchInventoryStale, inventoryStaleFetchStatus, inventoryStaleSummary,
     fetchInventoryWarning, inventoryWarningFetchStatus, inventoryWarningSummary,
-    fetchInventoryTotal, inventoryTotalFetchStatus, inventoryTotalSummary
+    fetchInventoryTotal, inventoryTotalFetchStatus, inventoryTotalSummary,
+    selectedTags, workloads
 }) => {
     const { hasAccess } = usePermissions('inventory', [
         'inventory:*:*',
@@ -31,14 +34,33 @@ const SystemInventoryCard = ({
         'inventory:hosts:read'
     ]);
     useEffect(() => {
-        fetchInventoryTotal();
-        fetchInventory();
-        fetchInventoryStale();
-        fetchInventoryWarning();
+        const sapFilter = workloads?.SAP?.isSelected ? generateFilter({
+            system_profile: {
+                sap_system: true
+            }
+        }) : undefined;
+        fetchInventoryTotal({
+            ...sapFilter,
+            ...selectedTags.length > 0 && { tags: selectedTags.join() }
+        });
+        fetchInventory({
+            ...sapFilter,
+            ...selectedTags.length > 0 && { tags: selectedTags.join() }
+        });
+        fetchInventoryStale({
+            ...sapFilter,
+            ...selectedTags.length > 0 && { tags: selectedTags.join() }
+        });
+        fetchInventoryWarning({
+            ...sapFilter,
+            ...selectedTags.length > 0 && { tags: selectedTags.join() }
+        });
     }, [fetchInventoryTotal,
         fetchInventory,
         fetchInventoryStale,
-        fetchInventoryWarning]
+        fetchInventoryWarning,
+        selectedTags,
+        workloads]
     );
 
     const intl = useIntl();
@@ -116,7 +138,20 @@ SystemInventoryCard.propTypes = {
     fetchInventoryTotal: PropTypes.func,
     inventoryTotalSummary: PropTypes.object,
     inventoryTotalFetchStatus: PropTypes.string,
-    intl: PropTypes.any
+    intl: PropTypes.any,
+    selectedTags: PropTypes.arrayOf(PropTypes.string),
+    workloads: PropTypes.oneOf([
+        PropTypes.shape({
+            SAP: PropTypes.shape({
+                isSelected: PropTypes.bool
+            })
+        }),
+        PropTypes.shape({
+            'All workloads': PropTypes.shape({
+                isSelected: PropTypes.bool
+            })
+        })
+    ])
 };
 
 export default connect(
@@ -128,12 +163,14 @@ export default connect(
         inventoryWarningSummary: DashboardStore.inventoryWarningSummary,
         inventoryWarningFetchStatus: DashboardStore.inventoryWarningFetchStatus,
         inventoryTotalSummary: DashboardStore.inventoryTotalSummary,
-        inventoryTotalFetchStatus: DashboardStore.inventoryTotalFetchStatus
+        inventoryTotalFetchStatus: DashboardStore.inventoryTotalFetchStatus,
+        selectedTags: DashboardStore.selectedTags,
+        workloads: DashboardStore.workloads
     }),
     dispatch => ({
-        fetchInventory: () => dispatch(AppActions.fetchInventorySummary()),
-        fetchInventoryStale: () => dispatch(AppActions.fetchInventoryStaleSummary()),
-        fetchInventoryWarning: () => dispatch(AppActions.fetchInventoryWarningSummary()),
-        fetchInventoryTotal: () => dispatch(AppActions.fetchInventoryTotalSummary())
+        fetchInventory: (params) => dispatch(AppActions.fetchInventorySummary(params)),
+        fetchInventoryStale: (params) => dispatch(AppActions.fetchInventoryStaleSummary(params)),
+        fetchInventoryWarning: (params) => dispatch(AppActions.fetchInventoryWarningSummary(params)),
+        fetchInventoryTotal: (params) => dispatch(AppActions.fetchInventoryTotalSummary(params))
     })
 )(SystemInventoryCard);

--- a/src/SmartComponents/SystemInventory/SystemInventoryCard.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryCard.js
@@ -16,6 +16,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
+import { workloadsPropType } from '../../Utilities/Common';
 
 /**
  * System inventory card for showing system inventory and status.
@@ -140,18 +141,7 @@ SystemInventoryCard.propTypes = {
     inventoryTotalFetchStatus: PropTypes.string,
     intl: PropTypes.any,
     selectedTags: PropTypes.arrayOf(PropTypes.string),
-    workloads: PropTypes.oneOf([
-        PropTypes.shape({
-            SAP: PropTypes.shape({
-                isSelected: PropTypes.bool
-            })
-        }),
-        PropTypes.shape({
-            'All workloads': PropTypes.shape({
-                isSelected: PropTypes.bool
-            })
-        })
-    ])
+    workloads: workloadsPropType
 };
 
 export default connect(

--- a/src/Utilities/Common.js
+++ b/src/Utilities/Common.js
@@ -1,3 +1,27 @@
 // For common helpers used throughout app
-
+const SAP_KEYS = ['SAP', 'All workloads'];
 export const capitalize = (string) => string[0].toUpperCase() + string.substring(1);
+export const workloadsPropType = (props, propName, componentName) => {
+    let error;
+    const prop = props?.[propName];
+    if (typeof props !== 'object') {
+        error = new Error(`\`${componentName}\` only accepts object as \`${propName}\` prop.`);
+    }
+
+    const keys = Object.keys(prop);
+    if (keys.some((key) => !SAP_KEYS.includes(key))) {
+        error = new Error(`\`${componentName}\` accepts either SAP or All workloads as \`${propName}.\` prop.`);
+    }
+
+    if (keys.find((key) => SAP_KEYS.includes(key))?.length > 1) {
+        error = new Error(`\`${componentName}\` accepts only one of SAP or All workloads as \`${propName}.\` prop.`);
+    }
+
+    const values = Object.values(prop);
+    const foundIncorrect = values.findIndex(({ isSelected }) => isSelected !== undefined && typeof isSelected !== 'boolean');
+    if (foundIncorrect !== -1) {
+        error = new Error(`\`${componentName}\` requires isSelected as boolean prop in \`${propName}.${keys?.[foundIncorrect]}\`.`);
+    }
+
+    return error;
+};


### PR DESCRIPTION
## What

Enable global filter tags and sap_system to be passed down to inventory enpoints. Use `generateFilter` from frontend components (it has been added recentrly) in order to properly style the filter for inventory to be `filter[system_profile][sap_syste]: true`. This function can later help us to calculate SAP_SIDs as well.

## Screenshots

### Before
![Screenshot from 2020-10-08 16-38-38](https://user-images.githubusercontent.com/3439771/95473826-c4fa4080-0984-11eb-9bfe-044936588821.png)
![Screenshot from 2020-10-08 16-38-46](https://user-images.githubusercontent.com/3439771/95473827-c592d700-0984-11eb-9561-b142139632fb.png)


### After
![Screenshot from 2020-10-08 16-37-03](https://user-images.githubusercontent.com/3439771/95473705-a72cdb80-0984-11eb-8535-e8653c032637.png)
![Screenshot from 2020-10-08 16-37-37](https://user-images.githubusercontent.com/3439771/95473706-a7c57200-0984-11eb-8332-5d5ffb836871.png)


## Additional Info
[if needed]

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker
