### PR TITLE
Do not hide global filter trough CSS

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,6 +73,9 @@ const App = (props) => {
         );
         const inventorySystems = await API.get(`${INVENTORY_TOTAL_FETCH_URL}`);
         setHasSystems(inventorySystems.data.total > 0);
+        if (inventorySystems.data.total <= 0) {
+            insights.chrome.hideGlobalFilter();
+        }
     }
 
     useEffect(() => {

--- a/src/PresentationalComponents/ZeroState/_zero-state.scss
+++ b/src/PresentationalComponents/ZeroState/_zero-state.scss
@@ -2,10 +2,6 @@
 
 $ins-c-marketing-banner--breakpoint-map: build-breakpoint-map();
 
-.ins-c-chrome__global-filter {
-  display: none;
-}
-
 .ins-c-marketing-page {
   --ins-m-marketing-page--RowGap: var(--pf-global--spacer--xl);
   --ins-m-marketing-page--ColumnGap: var(--pf-global--spacer--xl);


### PR DESCRIPTION
## What

When user access dashboard, global filter is hidden all the time, this is caused by CSS rule, instead of hiding this trough CSS hide it trough chrome API.

## Code Review
@ryelo @AllenBW

