### PR TITLE
fix(compliance): RHICOMPL-1181 Group results by policy

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -9,7 +9,8 @@ export const SID_SET = 'SID_SET';
 
 // Compliance App Constants
 export const COMPLIANCE_FETCH = 'COMPLIANCE_SUMMARY_FETCH';
-export const COMPLIANCE_FETCH_URL = `${BASE_URL}/compliance/profiles?search=has_test_results=true`;
+export const COMPLIANCE_SEARCH = encodeURIComponent('(has_policy_test_results=true AND external=false) OR (has_policy=false AND has_test_results=true)');
+export const COMPLIANCE_FETCH_URL = `${BASE_URL}/compliance/profiles?search=${COMPLIANCE_SEARCH}`;
 
 // Vulnerability App Constants
 const VULN_CVES = '/vulnerability/v1/report/executive';

--- a/src/SmartComponents/Compliance/ComplianceCard.js
+++ b/src/SmartComponents/Compliance/ComplianceCard.js
@@ -11,6 +11,7 @@ import {
 import React, { useEffect } from 'react';
 import { TemplateCard, TemplateCardBody, TemplateCardHeader } from '../../PresentationalComponents/Template/TemplateCard';
 import { chart_color_blue_200, chart_color_blue_300 } from '@patternfly/react-tokens';
+import { global_palette_black_300 } from '@patternfly/react-tokens/dist/esm/';
 import { supportsGlobalFilter, workloadsPropType } from '../../Utilities/Common';
 
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
@@ -75,17 +76,18 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                                                     data={ [
                                                         {
                                                             x: 'Compliant',
-                                                            y: policy.attributes.compliant_host_count
+                                                            y: policy.attributes.test_result_host_count ? policy.attributes.compliant_host_count : '0'
                                                         }, {
                                                             x: 'Non-compliant',
-                                                            y: policy.attributes.total_host_count - policy.attributes.compliant_host_count
+                                                            y: policy.attributes.test_result_host_count - policy.attributes.compliant_host_count
                                                         }
                                                     ] }
                                                     labels={ ({ datum }) => `${datum.x}: ${datum.y}` }
                                                     padding={ pieChartPadding }
                                                     height={ 65 }
                                                     width={ 65 }
-                                                    colorScale={ colorScale }
+                                                    colorScale={ policy.attributes.test_result_host_count === 0 ?
+                                                        [global_palette_black_300.value] : colorScale }
                                                 />
                                             </div>
                                             <div className="ins-c-compliance__row-item">
@@ -102,16 +104,17 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                                                 <Split hasGutter>
                                                     <SplitItem>
                                                         {intl.formatMessage(messages.compliantHostCount,
-                                                            { count: policy.attributes.total_host_count }
+                                                            { count: policy.attributes.test_result_host_count }
                                                         )}
                                                     </SplitItem>
                                                     <SplitItem>
                                                         {intl.formatMessage(messages.compliantScore,
                                                             {
-                                                                score: +(
-                                                                    100 * (
-                                                                        policy.attributes.compliant_host_count / policy.attributes.total_host_count
-                                                                    )
+                                                                score: +(policy.attributes.test_result_host_count &&
+                                                                    (100 * (
+                                                                        policy.attributes.compliant_host_count /
+                                                                        policy.attributes.test_result_host_count
+                                                                    ))
                                                                 ).toFixed(1)
                                                             }
                                                         )}


### PR DESCRIPTION
## Prerequisites

- [x] Scope your styles to your individual card
- [x] You are using translations when necessary with proper plural/singular modifications
- [x] You are using the template card provided
- [x] Use functional components & hooks (please)
- [x] Attach screenshots (before and after)
- [x] Make sure that all text in blue is populated with the correct link. If you're unsure what the url should be, just ask!

## What

:warning: :warning: :warning: Requires https://github.com/RedHatInsights/compliance-backend/pull/677 :warning: :warning: :warning:

Please DO NOT MERGE this PR until we give the OK from our side that we have shipped this backend PR to prod.

Related to recent feature COMP-E-152, compliance reports should be
grouped by policy. This change should fix the dashboard to reflect the
results shown in the new compliance reports page.

In addition, unsupported reports are no longer counted in the compliant or total (renamed to test_result_count) count. For now, those hosts are not shown in the dashboard at all.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/761923/101410163-edcb8300-38ac-11eb-9e81-f5f58e199242.png)

### After
![image](https://user-images.githubusercontent.com/761923/101502208-af7ea400-393e-11eb-991c-868c7689992c.png)

## Additional Info
:warning: :warning: :warning: Requires https://github.com/RedHatInsights/compliance-backend/pull/677 :warning: :warning: :warning:

## Code Review
@christiemolloy @ryelo @AllenBW

## Design Review
@kybaker

Signed-off-by: Andrew Kofink <akofink@redhat.com>