### PR TITLE
Rename custom Dashboard webpack chunk name.

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,7 +3,7 @@ import { Route, Switch } from 'react-router-dom';
 
 import Loading from './PresentationalComponents/Loading/Loading';
 
-const Dashboard = lazy(() => import(/* webpackChunkName: 'Dashboard' */ './PresentationalComponents/Dashboard/Dashboard'));
+const Dashboard = lazy(() => import(/* webpackChunkName: 'dashboard-route' */ './PresentationalComponents/Dashboard/Dashboard'));
 export const Routes = () => {
     return (
         <Switch>


### PR DESCRIPTION
Fixes hot reload issue:
```bash
 ｢wdm｣: Error: Prevent writing to file that only differs in casing or query string from already written file.
This will lead to a race-condition and corrupted files on case-insensitive file systems.
/Users/mattnolting/Web/insights-master/insights-dashboard/dist/Dashboard.21df37310ce7ebf394cc.hot-update.js
/Users/mattnolting/Web/insights-master/insights-dashboard/dist/dashboard.21df37310ce7ebf394cc.hot-update.js
```

In short, this is why we had this issue. We have a file called `Dashboard` and a custom lazy import chunk also called `Dashboard` set by `/* webpackChunkName: "Dashboard" */`. But the hot-update chunks are lowercased. The first build passes because there are no hot-loaded files yet. After any change in `Dashboard.js` file, webpack generates hot-update files for both the `Dashboard.js` and the custom chunk name. Both have `[d|D]asboard.[hash].hot-update.js` file name and because there is the same content, they also have the same hash. The only difference is in the letter "D" and its casing. The build then crashes because of the possible issues with case insensitivity. In fact, if we use `/* webpackChunkName: "dashboard" */` (lower cased "d") the app won't even build for the first time and webpack crashes immediately because we now have chunknames with both "d" and "D".

Renaming the chunk name to anything else fixes the issue.

cc @christiemolloy @ryelo @AllenBW @mattnolting Please double check the dev server works.