### PR TITLE
Hide unregistered, unifies patch/subwatch title, persist card expanded 🤯

### DIFF
--- a/src/PresentationalComponents/Template/ExpandableCardTemplate.js
+++ b/src/PresentationalComponents/Template/ExpandableCardTemplate.js
@@ -1,53 +1,37 @@
-// components
-import {
-    Card,
-    CardExpandableContent,
-    CardHeader,
-    CardTitle,
-    Divider,
-    Title
-} from '@patternfly/react-core/dist/esm/components';
+import { Card, CardExpandableContent, CardHeader, CardTitle, Divider, Title } from '@patternfly/react-core/dist/esm/components';
 import React, { useState } from 'react';
 
 import propTypes from 'prop-types';
 
-export const ExpandableCardTemplate = ({ className, appName, title, header, body, hasDivider, ...props }) => {
-    const [isExpanded, setIsExpanded] = useState(true);
+export const ExpandableCardTemplate = ({ className, appName, title, header, body, hasDivider, isExpanded = true, isExpandedCallback, ...props }) => {
+    const [expanded, setExpanded] = useState(isExpanded);
 
-    return (
-        <React.Fragment>
-            <Card
-                className={ `ins-c-dashboard__card ins-c-dashboard__card--${appName} ${className}` }
-                id={ `ins-c-dashboard__card--${appName}` }
-                isExpanded={ isExpanded }
-                { ...props }
-            >
-                { hasDivider &&
-                    <Divider inset={ { md: 'insetLg' } } />
-                }
-                <CardHeader
-                    onExpand={() => setIsExpanded(!isExpanded)}
-                    toggleButtonProps={{
-                        id: `ins-c-dashboard__card-title--${appName}-toggle-button`,
-                        'aria-label': 'Details',
-                        'aria-labelledby': `ins-c-dashboard__card-title--${appName} toggle-button`,
-                        'aria-expanded': isExpanded }}
-                >
-                    { title &&
-                        <CardTitle>
-                            <Title headingLevel="h2" size="lg">
-                                { title }
-                            </Title>
-                        </CardTitle>
-                    }
-                    { header }
-                </CardHeader>
-                <CardExpandableContent>
-                    { body }
-                </CardExpandableContent>
-            </Card>
-        </React.Fragment>
-    );
+    return <Card
+        className={`ins-c-dashboard__card ins-c-dashboard__card--${appName} ${className}`}
+        id={`ins-c-dashboard__card--${appName}`}
+        isExpanded={expanded}
+        {...props}>
+        {hasDivider && <Divider inset={{ md: 'insetLg' }} />}
+        <CardHeader
+            onExpand={() => { setExpanded(!expanded); isExpandedCallback && isExpandedCallback(!expanded); }}
+            toggleButtonProps={{
+                id: `ins-c-dashboard__card-title--${appName}-toggle-button`,
+                'aria-label': 'Details',
+                'aria-labelledby': `ins-c-dashboard__card-title--${appName} toggle-button`,
+                'aria-expanded': expanded
+            }}>
+            {title && <CardTitle>
+                <Title headingLevel="h2" size="lg">
+                    {title}
+                </Title>
+            </CardTitle>
+            }
+            {header}
+        </CardHeader>
+        <CardExpandableContent>
+            {body}
+        </CardExpandableContent>
+    </Card>;
 };
 
 ExpandableCardTemplate.propTypes = {
@@ -57,5 +41,7 @@ ExpandableCardTemplate.propTypes = {
     header: propTypes.any,
     body: propTypes.any,
     hasDivider: propTypes.any,
+    isExpanded: propTypes.bool,
+    isExpandedCallback: propTypes.func,
     footer: propTypes.footer
 };

--- a/src/SmartComponents/Advisor/Advisor.js
+++ b/src/SmartComponents/Advisor/Advisor.js
@@ -139,7 +139,9 @@ const Advisor = () => {
                     appName='Advisor'
                     className='ins-m-toggle-right-on-md'
                     title={intl.formatMessage(messages.advisorCardHeader1)}
-                    body={<TemplateCardBody className="ins-c-advisor-recs__card-body">
+                    isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_advisor1') || 'true')}
+                    isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_advisor1', isExpanded)}
+                    body={<TemplateCardBody className='ins-c-advisor-recs__card-body'>
                         <Grid hasGutter>
                             <Flex
                                 direction={{ default: 'column' }}
@@ -148,7 +150,7 @@ const Advisor = () => {
                                 <Flex>
                                     {advisorIncidents?.meta?.count > 0 &&
                                         <ExclamationTriangleIcon className='pf-u-font-size-xl pf-u-warning-color-100' />}
-                                    <span className="pf-u-font-size-2xl pf-u-text-align-center pf-u-font-weight-normal">
+                                    <span className='pf-u-font-size-2xl pf-u-text-align-center pf-u-font-weight-normal'>
                                         {intl.formatMessage(messages.incidents, { incidents: advisorIncidents?.meta?.count })}
                                     </span>
                                 </Flex>
@@ -172,7 +174,9 @@ const Advisor = () => {
                         {intl.formatMessage(messages.advisorCardHeader2)}
                         {iconTooltip(intl.formatMessage(messages.totalRiskDef, { em: str => <em>{str}</em> }))}
                     </React.Fragment>}
-                    body={<TemplateCardBody className="ins-c-advisor-recs__card-body pf-u-pb-0">
+                    isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_advisor2') || 'true')}
+                    isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_advisor2', isExpanded)}
+                    body={<TemplateCardBody className='ins-c-advisor-recs__card-body pf-u-pb-0'>
                         <Flex justifyContent={{ default: 'justifyContentSpaceEvenly' }}>
                             {trData.map(({ title, risk, value }) =>
                                 <a key={title} href={totalRiskUrl(value)}>
@@ -180,22 +184,22 @@ const Advisor = () => {
                                         direction={{ default: 'column' }}
                                         spaceItems={{ default: 'spaceItemsNone' }}
                                         alignItems={{ default: 'alignItemsCenter' }}>
-                                        <span className="pf-u-font-size-2xl pf-u-color-100 pf-u-font-weight-normal">
+                                        <span className='pf-u-font-size-2xl pf-u-color-100 pf-u-font-weight-normal'>
                                             {risk}
                                         </span>
-                                        <span className="pf-u-font-size-sm">
+                                        <span className='pf-u-font-size-sm'>
                                             {title}
                                         </span>
                                     </Flex>
                                 </a>)}
                         </Flex>
-                        <Card component="div">
+                        <Card component='div'>
                             <CardTitle>
-                                <Title headingLevel="h4" size="lg">
+                                <Title headingLevel='h4' size='lg'>
                                     {intl.formatMessage(messages.advisorCardHeader3)}
                                 </Title>
                             </CardTitle>
-                            <CardBody className="pf-u-pt-sm">
+                            <CardBody className='pf-u-pt-sm'>
                                 <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                                     <Flex alignItems={{ default: 'alignItemsCenter' }}>
                                         <FlexItem>
@@ -207,14 +211,14 @@ const Advisor = () => {
                                                 colorScale={colorScale}
                                                 padding={pieChartPadding}
                                                 height={100}
-                                                width={100}/>
+                                                width={100} />
                                         </FlexItem>
-                                        <div className="ins-c-legend">
+                                        <div className='ins-c-legend'>
                                             {pieLegendData.map((item) =>
-                                                <a key={item.url} href={item.url} className="ins-c-legend__item">
-                                                    <span className="ins-c-legend__dot"
+                                                <a key={item.url} href={item.url} className='ins-c-legend__item'>
+                                                    <span className='ins-c-legend__dot'
                                                         style={{ '--ins-c-legend__dot--BackgroundColor': `${item.fill}` }} />
-                                                    <span className="ins-c-legend__text">{item.name}</span>
+                                                    <span className='ins-c-legend__text'>{item.name}</span>
                                                 </a>
                                             )}
                                         </div>

--- a/src/SmartComponents/Advisor/Advisor.scss
+++ b/src/SmartComponents/Advisor/Advisor.scss
@@ -1,1 +1,6 @@
 @import '../../App.scss';
+
+.ins-c-info-icon {
+    padding-top: 0;
+    padding-bottom: 0;
+}

--- a/src/SmartComponents/Compliance/ComplianceCard.js
+++ b/src/SmartComponents/Compliance/ComplianceCard.js
@@ -15,19 +15,11 @@ import {
     EmptyStateVariant,
     Title
 } from '@patternfly/react-core/dist/esm/components';
-import {
-    Flex,
-    FlexItem
-} from '@patternfly/react-core/dist/esm/layouts';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts';
 import React, { useEffect } from 'react';
-// template card
-import {
-    TemplateCardActions,
-    TemplateCardBody
-} from '../../PresentationalComponents/Template/TemplateCard';
+import { TemplateCardActions, TemplateCardBody } from '../../PresentationalComponents/Template/TemplateCard';
 import { supportsGlobalFilter, workloadsPropType } from '../../Utilities/Common';
 
-// expandable card
 import { ExpandableCardTemplate } from '../../PresentationalComponents/Template/ExpandableCardTemplate';
 import FailState from '../../PresentationalComponents/FailState/FailState';
 import FilterNotSupported from '../../PresentationalComponents/FilterNotSupported';
@@ -65,6 +57,8 @@ const ComplianceCard = ({ fetchCompliance, complianceFetchStatus, complianceSumm
                 'data-ouia-safe': true
             } : { 'data-ouia-safe': false } }
             title={ intl.formatMessage(messages.complianceTitle) }
+            isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_compliance') || 'true')}
+            isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_compliance', isExpanded)}
             header={
                 <TemplateCardActions />
             }

--- a/src/SmartComponents/NewRules/NewRules.js
+++ b/src/SmartComponents/NewRules/NewRules.js
@@ -30,7 +30,7 @@ import { useSelector } from 'react-redux';
 
 const NewRules = () => {
     const intl = useIntl();
-    const [isExpanded, setIsExpanded] = useState(JSON.parse(localStorage.getItem('DashboardNewRulesExpanded') || 'true'));
+    const [isExpanded, setIsExpanded] = useState(JSON.parse(localStorage.getItem('dashboard_expanded_cta') || 'true'));
     const vulnerabilities = useSelector(({ DashboardStore }) => DashboardStore.vulnerabilities);
     let { recent_rules: newRules } = vulnerabilities;
     const severitColor = {
@@ -58,7 +58,7 @@ const NewRules = () => {
                 />
                 <div className='pf-c-data-list__item-control'>
                     <div className='pf-c-data-list__toggle'
-                        onClick={() => { localStorage.setItem('DashboardNewRulesExpanded', `${!isExpanded}`); setIsExpanded(!isExpanded); }}
+                        onClick={() => { localStorage.setItem('dashboard_expanded_cta', `${!isExpanded}`); setIsExpanded(!isExpanded); }}
                         isExpanded={isExpanded}
                         id={`data-list-toggle`}
                         aria-controls={`data-list-item`}>

--- a/src/SmartComponents/PatchManager/PatchManagerCard.js
+++ b/src/SmartComponents/PatchManager/PatchManagerCard.js
@@ -7,6 +7,7 @@ import { patchmanFetchBugs, patchmanFetchEnhancements, patchmanFetchSecurity, pa
 import { sapFilter, workloadsPropType } from '../../Utilities/Common';
 
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
+import { ExpandableCardTemplate } from '../../PresentationalComponents/Template/ExpandableCardTemplate';
 import FailState from '../../PresentationalComponents/FailState/FailState';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import { PieChart } from '../../ChartTemplates/PieChart/PieChartTemplate';
@@ -49,53 +50,50 @@ const PatchManagerCard = ({ systems, systemsStatus, fetchSystems, fetchSecurity,
 
     if (systemsStatus === 'rejected') {
         return (
-            <TemplateCard appName='PatchManager' className={ 'ins-c-dashboard__card--Patch' }>
-                <TemplateCardHeader subtitle={ intl.formatMessage(messages.patchTitle) } />
+            <TemplateCard appName='PatchManager' className={'ins-c-dashboard__card--Patch'}>
+                <TemplateCardHeader subtitle={intl.formatMessage(messages.patchTitle)} />
                 <TemplateCardBody><FailState appName='Patch' isSmall /></TemplateCardBody>
             </TemplateCard>
         );
     }
 
-    return <TemplateCard appName='PatchManager' className={ 'ins-c-dashboard__card--Patch' }>
-        <TemplateCardHeader
-            title={ intl.formatMessage(messages.patchTitle) }
-            subtitle={
-                <Button
-                    component="a"
-                    href={ `${UI_BASE}/${PATCHMAN_ID}/systems` }
-                    variant="link"
-                    isInline
-                >
-                    <span>{intl.formatMessage(messages.systemsAffected, { count: systems })}</span>
-                </Button>
-            }
-        />
-
-        <TemplateCardBody>
+    return <ExpandableCardTemplate appName='PatchManager'
+        isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_patch') || 'true')}
+        isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_patch', isExpanded)}
+        title={intl.formatMessage(messages.patchTitle)}
+        className={'ins-c-dashboard__card--Patch ins-m-toggle-right-on-md'}
+        body={<TemplateCardBody>
             {!isLoaded ? <Loading /> :
                 <React.Fragment>
-                    <div className="ins-c-patch__chart">
+                    <Button
+                        component='a'
+                        href={`${UI_BASE}/${PATCHMAN_ID}/systems`}
+                        variant='link'
+                        isInline>
+                        <span>{intl.formatMessage(messages.systemsAffected, { count: systems })}</span>
+                    </Button>
+                    <div className='ins-c-patch__chart'>
                         <PieChart
-                            ariaDesc="Patch systems chart"
-                            ariaTitle="Patch systems chart"
-                            constrainToVisibleArea={ true }
-                            data={ pieChartData }
-                            labels={ ({ datum }) => `${datum.x}: ${datum.y}` }
-                            padding={ pieChartPadding }
-                            height={ 65 }
-                            width={ 65 }
-                            colorScale={ colorScale }
-                            legend="true"
-                            legendData={ pieChartLegendData }
-                            legendOrientation="vertical"
-                            legendHeight={ 75 }
-                            legendWidth={ 200 }
+                            ariaDesc='Patch systems chart'
+                            ariaTitle='Patch systems chart'
+                            constrainToVisibleArea={true}
+                            data={pieChartData}
+                            labels={({ datum }) => `${datum.x}: ${datum.y}`}
+                            padding={pieChartPadding}
+                            height={65}
+                            width={65}
+                            colorScale={colorScale}
+                            legend='true'
+                            legendData={pieChartLegendData}
+                            legendOrientation='vertical'
+                            legendHeight={75}
+                            legendWidth={200}
                         />
                     </div>
                 </React.Fragment>
             }
-        </TemplateCardBody>
-    </TemplateCard>;
+        </TemplateCardBody>}
+    />;
 };
 
 PatchManagerCard.propTypes = {

--- a/src/SmartComponents/Remediations/RemediationsCard.js
+++ b/src/SmartComponents/Remediations/RemediationsCard.js
@@ -34,6 +34,8 @@ const RemediationsCard = ({
             appName='remediations'
             className='ins-c-card__remediations ins-m-toggle-right-on-md'
             title={ intl.formatMessage(messages.remediationsCardHeader) }
+            isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_remediations') || 'true')}
+            isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_remediations', isExpanded)}
             header={
                 <TemplateCardActions />
             }

--- a/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.js
+++ b/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.js
@@ -14,19 +14,20 @@ import {
     SW_PATHS
 } from './Constants';
 import React, { useEffect, useState } from 'react';
-import { TemplateCard, TemplateCardBody, TemplateCardHeader } from '../../PresentationalComponents/Template/TemplateCard';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
 import { filterChartData, setRangedDateTime } from './SubscriptionsUtilizedHelpers';
 import { supportsGlobalFilter, workloadsPropType } from '../../Utilities/Common';
 
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
 import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyStateSecondaryActions';
+import { ExpandableCardTemplate } from '../../PresentationalComponents/Template/ExpandableCardTemplate';
 import FailState from '../../PresentationalComponents/FailState/FailState';
 import FilterNotSupported from '../../PresentationalComponents/FilterNotSupported';
 import Immutable from 'seamless-immutable';
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import { ProgressTemplate } from '../../../../insights-dashboard/src/ChartTemplates/Progress/ProgressTemplate';
 import PropTypes from 'prop-types';
+import { TemplateCardBody } from '../../PresentationalComponents/Template/TemplateCard';
 import { connect } from 'react-redux';
 import messages from '../../Messages';
 import moment from 'moment/moment';
@@ -97,18 +98,18 @@ const SubscriptionsUtilizedCard = ({ subscriptionsUtilizedProductOne, subscripti
 
     const productTwoTooltip = (
         <ul>
-            <li>{ intl.formatMessage(messages.subscriptionsUtilizedProductTwoReport, { totalReport: productTwo.report }) }</li>
-            <li>{ intl.formatMessage(messages.subscriptionsUtilizedProductCapacity, { totalCapacity: productTwo.capacity }) }</li>
-            <li>{ intl.formatMessage(messages.subscriptionsUtilizedProductDate,
-                { formattedDate: moment.utc(productTwo.date).format('MMM D, YYYY') }) }</li>
+            <li>{intl.formatMessage(messages.subscriptionsUtilizedProductTwoReport, { totalReport: productTwo.report })}</li>
+            <li>{intl.formatMessage(messages.subscriptionsUtilizedProductCapacity, { totalCapacity: productTwo.capacity })}</li>
+            <li>{intl.formatMessage(messages.subscriptionsUtilizedProductDate,
+                { formattedDate: moment.utc(productTwo.date).format('MMM D, YYYY') })}</li>
         </ul>
     );
     const productOneTooltip = (
         <ul>
-            <li>{ intl.formatMessage(messages.subscriptionsUtilizedProductOneReport, { totalReport: productOne.report }) }</li>
-            <li>{ intl.formatMessage(messages.subscriptionsUtilizedProductCapacity, { totalCapacity: productOne.capacity }) }</li>
-            <li>{ intl.formatMessage(messages.subscriptionsUtilizedProductDate,
-                { formattedDate: moment.utc(productOne.date).format('MMM D, YYYY') }) }</li>
+            <li>{intl.formatMessage(messages.subscriptionsUtilizedProductOneReport, { totalReport: productOne.report })}</li>
+            <li>{intl.formatMessage(messages.subscriptionsUtilizedProductCapacity, { totalCapacity: productOne.capacity })}</li>
+            <li>{intl.formatMessage(messages.subscriptionsUtilizedProductDate,
+                { formattedDate: moment.utc(productOne.date).format('MMM D, YYYY') })}</li>
         </ul>
     );
 
@@ -116,27 +117,27 @@ const SubscriptionsUtilizedCard = ({ subscriptionsUtilizedProductOne, subscripti
     const generateCharts = ({ fetchStatus, percentage, title, tooltip, link }) => {
         switch (fetchStatus) {
             case 'pending':
-                charts.push(<Loading key={ `su-loading-${title}` } />);
+                charts.push(<Loading key={`su-loading-${title}`} />);
                 break;
             case 'fulfilled':
                 if (percentage !== undefined && percentage !== null) {
                     charts.push(
                         <Tooltip
-                            key={ `su-tooltip-${title}` }
-                            content={ tooltip }
-                            position={ TooltipPosition.top }
-                            distance={ -10 }
-                            entryDelay={ 200 }
+                            key={`su-tooltip-${title}`}
+                            content={tooltip}
+                            position={TooltipPosition.top}
+                            distance={-10}
+                            entryDelay={200}
                         >
-                            <Button className="ins-c-subscriptions-utilized__chart-link"
-                                variant="link"
-                                href={ link } component="a"
+                            <Button className='ins-c-subscriptions-utilized__chart-link'
+                                variant='link'
+                                href={link} component='a'
                             >
                                 <ProgressTemplate
-                                    title={ title }
-                                    value={ percentage }
-                                    label={ `${percentage}%` }
-                                    variant={ (percentage > 100 && 'danger') || 'info' }
+                                    title={title}
+                                    value={percentage}
+                                    label={`${percentage}%`}
+                                    variant={(percentage > 100 && 'danger') || 'info'}
                                 />
                             </Button>
                         </Tooltip>);
@@ -166,41 +167,44 @@ const SubscriptionsUtilizedCard = ({ subscriptionsUtilizedProductOne, subscripti
         charts.reverse();
     }
 
-    return <TemplateCard appName='SubscriptionsUtilized'>
-        <TemplateCardHeader title={ intl.formatMessage(messages.subscriptionsUtilizedTitle) }/>
-        <TemplateCardBody>
+    return <ExpandableCardTemplate appName='SubscriptionsUtilized'
+        className='ins-m-toggle-right-on-md'
+        title={intl.formatMessage(messages.subscriptionsUtilizedTitle)}
+        isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_subwatch') || 'true')}
+        isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_subwatch', isExpanded)}
+        body={<TemplateCardBody>
             {supportsGlobalFilter(selectedTags, workloads, SID) ?
                 <React.Fragment>
                     {
-                        (productOptIn && <EmptyState className="ins-c-subscriptions-utilized__empty-state" variant={ EmptyStateVariant.full }>
+                        (productOptIn && <EmptyState className='ins-c-subscriptions-utilized__empty-state' variant={EmptyStateVariant.full}>
                             <EmptyStateBody>
                                 {intl.formatMessage(messages.subscriptionsUtilizedLearnMore)}
                             </EmptyStateBody>
                             <EmptyStateSecondaryActions>
                                 <Button
-                                    className="ins-c-subscriptions-utilized__app-link"
-                                    variant="link"
-                                    href={ SW_PATHS.APP }
-                                    component="a"
+                                    className='ins-c-subscriptions-utilized__app-link'
+                                    variant='link'
+                                    href={SW_PATHS.APP}
+                                    component='a'
                                 >
                                     {intl.formatMessage(messages.subscriptionsUtilizedLearnMoreAction)}
                                 </Button>
                             </EmptyStateSecondaryActions>
                         </EmptyState>) ||
-                (productError && <FailState appName={ intl.formatMessage(messages.subscriptionsUtilizedTitle) } isSmall/>) ||
-                (!charts.length && <EmptyState className="ins-c-subscriptions-utilized__empty-state" variant={ EmptyStateVariant.full }>
-                    <EmptyStateBody>
-                        {intl.formatMessage(messages.subscriptionsUtilizedNoProductData)}
-                    </EmptyStateBody>
-                </EmptyState>) ||
-                charts
+                        (productError && <FailState appName={intl.formatMessage(messages.subscriptionsUtilizedTitle)} isSmall />) ||
+                        (!charts.length && <EmptyState className='ins-c-subscriptions-utilized__empty-state' variant={EmptyStateVariant.full}>
+                            <EmptyStateBody>
+                                {intl.formatMessage(messages.subscriptionsUtilizedNoProductData)}
+                            </EmptyStateBody>
+                        </EmptyState>) ||
+                        charts
                     }
                 </React.Fragment>
-                : <FilterNotSupported href={ SW_PATHS.APP } title={ intl.formatMessage(messages.filterNotApplicable) }
-                    appName={ intl.formatMessage(messages.subscriptionsTitle) } />
+                : <FilterNotSupported href={SW_PATHS.APP} title={intl.formatMessage(messages.filterNotApplicable)}
+                    appName={intl.formatMessage(messages.subscriptionsTitle)} />
             }
-        </TemplateCardBody>
-    </TemplateCard>;
+        </TemplateCardBody>}
+    />;
 };
 
 SubscriptionsUtilizedCard.propTypes = {
@@ -223,7 +227,8 @@ const mapStateToProps = ({ DashboardStore }) => ({
     subscriptionsUtilizedProductTwoFetchStatus: DashboardStore.subscriptionsUtilizedProductTwoFetchStatus,
     selectedTags: DashboardStore.selectedTags,
     workloads: DashboardStore.workloads,
-    SID: DashboardStore.SID });
+    SID: DashboardStore.SID
+});
 
 const mapDispatchToProps = dispatch => ({
     subscriptionsUtilizedProductOneFetch: (productId, options) => dispatch(AppActions.subscriptionsUtilizedProductOneFetch(productId, options)),

--- a/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import './SystemInventoryHeader.scss';
 
 import * as AppActions from '../../AppActions';
@@ -78,10 +79,10 @@ const SystemInventoryHeader = ({
                                 linkDescription={ intl.formatMessage(messages.systemInventoryDescription,
                                     { count: inventorySummary.total || 0 }
                                 ) }
-                                link='./insights/inventory'
+                                link='./insights/inventory/?status=fresh&status=stale&source=insights'
                             />
                         }
-                        {inventoryFetchStatus === 'fulfilled' && inventoryTotalFetchStatus === 'fulfilled' &&
+                        {/* {inventoryFetchStatus === 'fulfilled' && inventoryTotalFetchStatus === 'fulfilled' &&
                             <NumberDescription
                                 data={ inventoryTotalSummary.total - inventorySummary.total || 0 }
                                 dataSize="lg"
@@ -90,7 +91,7 @@ const SystemInventoryHeader = ({
                                 ) }
                                 link='./insights/inventory'
                             />
-                        }
+                        } */}
                     </Flex>
                     <Flex spaceItems={ { default: 'spaceItemsXl' } }
                         alignItems={ { default: 'alignItemsCenter' } }

--- a/src/SmartComponents/Vulnerability/VulnerabilityCard.js
+++ b/src/SmartComponents/Vulnerability/VulnerabilityCard.js
@@ -71,25 +71,25 @@ const VulnerabilityCard = () => {
         legendLink = chartData.map((data) => `${UI_BASE}/vulnerability/cves?cvss_from=${data.from}&cvss_to=${data.to}`);
 
         rows = [[{
-            title: <TableText wrapModifier="nowrap" className="ins-c-legend__dot"
+            title: <TableText wrapModifier='nowrap' className='ins-c-legend__dot'
                 style={{ '--ins-c-legend__dot--BackgroundColor': '#a30000' }}>
                 <a href={legendLink[0]}>8.0 - 10</a>
             </TableText>
         }, {
-            title: <a href={legendLink[0]} className="pf-u-text-align-center">{bySeverity['8to10'].count}</a>,
+            title: <a href={legendLink[0]} className='pf-u-text-align-center'>{bySeverity['8to10'].count}</a>,
             props: { textCenter: true }
         }
         ], [{
-            title: <TableText wrapModifier="nowrap" className="ins-c-legend__dot"
+            title: <TableText wrapModifier='nowrap' className='ins-c-legend__dot'
                 style={{ '--ins-c-legend__dot--BackgroundColor': '#ec7a08' }}>
-                <a href={legendLink[1]} className="pf-u-text-align-center">4.0 - 7.9</a>
+                <a href={legendLink[1]} className='pf-u-text-align-center'>4.0 - 7.9</a>
             </TableText>
         }, {
-            title: <a href={legendLink[1]} className="pf-u-text-align-center">{bySeverity['4to7.9'].count}</a>,
+            title: <a href={legendLink[1]} className='pf-u-text-align-center'>{bySeverity['4to7.9'].count}</a>,
             props: { textCenter: true }
         }
         ], [{
-            title: <TableText wrapModifier="nowrap" className="ins-c-legend__dot"
+            title: <TableText wrapModifier='nowrap' className='ins-c-legend__dot'
                 style={{ '--ins-c-legend__dot--BackgroundColor': '#f0ab00' }}>
                 <a href={legendLink[2]}>0.0 - 3.9</a>
             </TableText>
@@ -107,20 +107,22 @@ const VulnerabilityCard = () => {
         </TemplateCard>;
     }
 
-    return <Card component='div' className="ins-c-dashboard-card-parent" data-ouia-safe={vulnerabilitiesFetchStatus !== 'pending'}>
+    return <Card component='div' className='ins-c-dashboard-card-parent' data-ouia-safe={vulnerabilitiesFetchStatus !== 'pending'}>
         <ExpandableCardTemplate
             appName='Vulnerabilities'
             className='ins-m-toggle-right-on-md ins-m-short-header'
             data-ouia-safe={vulnerabilitiesFetchStatus !== 'pending'}
             title={intl.formatMessage(messages.vulnerabilitiesTitle)}
+            isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_vulnerability1') || 'true')}
+            isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_vulnerability1', isExpanded)}
             body={
                 vulnerabilitiesFetchStatus !== 'fulfilled' ? <Loading /> :
-                    <TemplateCardBody className="ins-c-custom-policies__card-body">
+                    <TemplateCardBody className='ins-c-custom-policies__card-body'>
                         <Flex
                             direction={{ default: 'column' }}
                             spaceItems={{ default: 'spaceItemsLg' }}>
                             <TextContent>
-                                <p className="pf-u-font-size-sm">
+                                <p className='pf-u-font-size-sm'>
                                     {intl.formatMessage(messages.vulnerabilityMessage)}
                                 </p>
                             </TextContent>
@@ -132,7 +134,7 @@ const VulnerabilityCard = () => {
                                 <Flex
                                     direction={{ default: 'column' }}
                                     spaceItems={{ default: 'spaceItemsNone' }}>
-                                    <a className="pf-u-font-size-2xl pf-u-text-align-center pf-u-color-100"
+                                    <a className='pf-u-font-size-2xl pf-u-text-align-center pf-u-color-100'
                                         href={`${UI_BASE}/vulnerability/`} rel='noreferrer'>
                                         {intl.formatMessage(messages.vulnerabilitiesTotalItems, { total: vulnerabilities.rules_total
                                             || vulnerabilities.rules_cves_total })}
@@ -140,14 +142,14 @@ const VulnerabilityCard = () => {
                                     <TextContent
                                         className='ins-c-width-limiter pf-u-text-align-center'
                                         style={{ '--ins-c-width-limiter--MaxWidth': '24ch' }}>
-                                        <p className="pf-u-font-size-sm">
+                                        <p className='pf-u-font-size-sm'>
                                             {intl.formatMessage(messages.cvesImpactingOneOrMoreSystems, { cves: vulnerabilities.rules_total
                                                 || vulnerabilities.rules_cves_total })}
                                         </p>
                                     </TextContent>
                                 </Flex>
-                                <Button component="a" href={`${UI_BASE}/vulnerability/cves?affecting=true,false&rule_presence=true`} rel='noreferrer'
-                                    variant="secondary" isSmall>
+                                <Button component='a' href={`${UI_BASE}/vulnerability/cves?affecting=true,false&rule_presence=true`} rel='noreferrer'
+                                    variant='secondary' isSmall>
                                     {intl.formatMessage(messages.vulnerabilityCardCTAText)}
                                 </Button>
                             </Flex>
@@ -159,15 +161,17 @@ const VulnerabilityCard = () => {
             className='ins-m-toggle-right-on-md'
             data-ouia-safe={vulnerabilitiesFetchStatus !== 'pending'}
             title={intl.formatMessage(messages.cveByCvssScoreTitle)}
+            isExpanded={JSON.parse(localStorage.getItem('dashboard_expanded_vulnerability2') || 'true')}
+            isExpandedCallback={isExpanded => localStorage.setItem('dashboard_expanded_vulnerability2', isExpanded)}
             hasDivider
             body={vulnerabilitiesFetchStatus !== 'fulfilled' ? <Loading /> :
-                <TemplateCardBody className="ins-c-custom-policies__card-body pf-u-pt-sm">
+                <TemplateCardBody className='ins-c-custom-policies__card-body pf-u-pt-sm'>
                     <Flex alignItems={{ default: 'alignItemsCenter' }}>
                         <FlexItem>
                             <PieChart
                                 ariaDesc={intl.formatMessage(messages.cvesImpactingSystems,
                                     { cves: vulnerabilities.cves_total })}
-                                ariaTitle="Vulnerabilities chart"
+                                ariaTitle='Vulnerabilities chart'
                                 constrainToVisibleArea={true}
                                 data={chartData}
                                 padding={pieChartPadding}
@@ -178,7 +182,7 @@ const VulnerabilityCard = () => {
                         <FlexItem flex={{ default: 'flex_1s' }}>
                             <Table
                                 borders={false}
-                                aria-label="Simple Table"
+                                aria-label='Simple Table'
                                 cells={columns}
                                 rows={rows}
                                 className='ins-m-no-styling'


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ADVISOR-1656

so now we persist card dropdown state through user session (page navigation/refresh) what you collapse stays collapsed, default is expanded

#### everything collapsed, page refreshed
![Screen Shot 2021-03-25 at 12 07 34 PM](https://user-images.githubusercontent.com/6640236/112505327-0e87ed80-8d63-11eb-83bc-8f48bb168e35.png)
