### PR TITLE
Respect beta path on Subscriptions card

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -2,6 +2,7 @@
 
 const BASE_URL = '/api';
 export const UI_BASE = './insights';
+export const UI_BASE_OPENSHIFT = './openshift';
 export const SELECTED_TAGS_SET = 'SELECTED_TAGS_SET';
 export const WORKLOADS_SET = 'WORKLOADS_SET';
 export const SID_SET = 'SID_SET';

--- a/src/SmartComponents/SubscriptionsUtilized/Constants.js
+++ b/src/SmartComponents/SubscriptionsUtilized/Constants.js
@@ -1,3 +1,5 @@
+import { UI_BASE, UI_BASE_OPENSHIFT } from '../../AppConstants';
+
 export const RHSM_API_RESPONSE_DATA = 'data';
 
 export const RHSM_API_RESPONSE_DATA_TYPES = {
@@ -28,7 +30,7 @@ export const RHSM_API_QUERY_GRANULARITY_TYPES = {
 };
 
 export const SW_PATHS = {
-    APP: '/insights/subscriptions',
-    RHEL: '/insights/subscriptions/rhel',
-    OPENSHIFT: '/openshift/subscriptions/openshift-container'
+    APP: `${UI_BASE}/subscriptions/rhel`,
+    RHEL: `${UI_BASE}/subscriptions/rhel`,
+    OPENSHIFT: `${UI_BASE_OPENSHIFT}/subscriptions/openshift-container`
 };


### PR DESCRIPTION
## Prerequisites

- [x] Make sure that all text in blue is populated with the correct link. If you're unsure what the url should be, just ask!

## What
- Adds an `openshift` base constant
- Updates the Subscription card with relative path references for both `insights` plus `openshift` so they work with both `stable` and `beta` paths.

### Before
On beta, Subscription links were pointing to `stable`
### After
On beta, Subscription links are linking to `beta`

## Additional Info
Per discussion @rblackbu @bclarhk since Subscriptions doesn't have a landing page the default "app" link aims at RHEL

## Code Review
@christiemolloy @ryelo @AllenBW

