### PR TITLE
fix url to Patch UI

### DIFF
--- a/src/SmartComponents/PatchManager/PatchManagerCard.js
+++ b/src/SmartComponents/PatchManager/PatchManagerCard.js
@@ -32,15 +32,15 @@ const PatchManagerCard = ({ systems, systemsStatus, fetchSystems, fetchSecurity,
     const pieChartData = [
         {
             x: intl.formatMessage(messages.securityAdvisories, { count: security }), y: security, fill: chart_color_blue_400.value,
-            url: `${UI_BASE}/${PATCHMAN_ID}/advisories?offset=0&filter%5Badvisory_type%5D=3`
+            url: `${UI_BASE}/${PATCHMAN_ID}/advisories?offset=0&filter%5Badvisory_type_name%5D=3`
         },
         {
             x: intl.formatMessage(messages.bugfixAdvisories, { count: bugs }), y: bugs, fill: chart_color_blue_300.value,
-            url: `${UI_BASE}/${PATCHMAN_ID}/advisories?offset=0&filter%5Badvisory_type%5D=2`
+            url: `${UI_BASE}/${PATCHMAN_ID}/advisories?offset=0&filter%5Badvisory_type_name%5D=2`
         },
         {
             x: intl.formatMessage(messages.enhancementAdvisories, { count: enhancements }), y: enhancements, fill: chart_color_blue_200.value,
-            url: `${UI_BASE}/${PATCHMAN_ID}/advisories?offset=0&filter%5Badvisory_type%5D=1`
+            url: `${UI_BASE}/${PATCHMAN_ID}/advisories?offset=0&filter%5Badvisory_type_name%5D=1`
         }
     ];
 


### PR DESCRIPTION
We have a bug related to the API column name change in production. The URL from dashboard to Patch should respect this change. This PR should fix the issue. It would be great if this can be reviewed ASAP. 