### PR TITLE
Do not cache RBAC permissions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ const App = (props) => {
             user => setIsOrgAdmin(user.identity.user.is_org_admin)
         );
         // TODO: Update this function to query multiple apps instead of empty request (limited by API)
-        insights.chrome.getUserPermissions().then(
+        insights.chrome.getUserPermissions('', true).then(
             dashboardPermissions => {
                 const permissionList = dashboardPermissions.length && dashboardPermissions.map(permissions => permissions.permission);
                 if (permissionList.length) {


### PR DESCRIPTION
Fixes a bug where:
1. Opening dashboard
2. Removing RBAC permissions
3. Opening dashboard again without refreshing
4. App would try to display cards based on outdated permissions cached in step 1

`getUserPermissions` has two arguments, first is `app` name (we pass empty string meaning all apps), and second is `bypassCache`, where true means do not cache, always get up-to-date permissions.