### PR TITLE
[DRFT-1006] Add systems to compare button

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -84,6 +84,6 @@ export const DRIFT_EVENTS_PAYLOAD_FETCH_URL = `${BASE_URL}/notifications/v1.0/no
 export const DRIFT_EVENTS_PAYLOAD_FETCH = 'DRIFT_EVENTS_PAYLOAD_FETCH';
 export const DRIFT_URL = `${UI_BASE}/drift`;
 export const DRIFT_BASELINES_URL = `${DRIFT_URL}/baselines`;
-export const DRIFT_COMPARE_URL = `${DRIFT_URL}/?baseline_ids`;
 export const TOP_BASELINES = 5;
+export const SYSTEMS_LIMIT = 4;
 

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -778,5 +778,10 @@ export default defineMessages({
         id: 'driftCompare',
         description: 'driftCompare',
         defaultMessage: 'Compare'
+    },
+    driftCompareTooltip: {
+        id: 'driftCompareTooltip',
+        description: 'driftCompareTooltip',
+        defaultMessage: 'This will compare the baseline with up to 4 systems'
     }
 });

--- a/src/SmartComponents/Drift/DriftCard.js
+++ b/src/SmartComponents/Drift/DriftCard.js
@@ -2,7 +2,7 @@ import './DriftCard.scss';
 
 import * as AppActions from '../../AppActions';
 import * as ActionTypes from '../../AppConstants';
-import { getDate } from './utils';
+import { getDate, buildCompareUrl } from './utils';
 
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -25,7 +25,8 @@ import {
     TextVariants,
     Text,
     Bullseye,
-    Spinner
+    Spinner,
+    Tooltip
 } from '@patternfly/react-core';
 import { DriftEmptyState } from './DriftEmptyState';
 import { useDispatch } from 'react-redux';
@@ -166,17 +167,23 @@ const DriftCard = () => {
                                                                         </span>
                                                                     </DataListCell>
                                                                     <DataListCell key={index} className='ins-c-drift__data_list_cell_compare'>
-                                                                        <Text
-                                                                            component={TextVariants.a}
-                                                                            href={`${ActionTypes.DRIFT_COMPARE_URL}=${baseline.baselineId}`}
-                                                                            className='ins-c-drift__text_compare'
-                                                                            onClick={(e) => navigateTo(
-                                                                                e,
-                                                                                `${ActionTypes.DRIFT_COMPARE_URL}=${baseline.baselineId}`
-                                                                            )}
-                                                                        >
-                                                                            {intl.formatMessage(messages.driftCompare)}
-                                                                        </Text>
+                                                                        <Tooltip
+                                                                            content={
+                                                                                <div>
+                                                                                    {intl.formatMessage(messages.driftCompareTooltip)}
+                                                                                </div>}>
+                                                                            <Text
+                                                                                component={TextVariants.a}
+                                                                                href={buildCompareUrl(baseline.baselineId, baseline.systems)}
+                                                                                className='ins-c-drift__text_compare'
+                                                                                onClick={(e) => navigateTo(
+                                                                                    e,
+                                                                                    buildCompareUrl(baseline.baselineId, baseline.systems)
+                                                                                )}
+                                                                            >
+                                                                                {intl.formatMessage(messages.driftCompare)}
+                                                                            </Text>
+                                                                        </Tooltip>
                                                                     </DataListCell>
                                                                 </React.Fragment>
                                                             ]}

--- a/src/SmartComponents/Drift/utils.js
+++ b/src/SmartComponents/Drift/utils.js
@@ -1,4 +1,5 @@
 import messages from '../../Messages';
+import * as ActionTypes from '../../AppConstants';
 
 export const groupPayload = (data) => {
     return data.reduce((acc, curr) => {
@@ -74,3 +75,14 @@ export const translateDriftDropdownItems = (intl) => ([
         endDate: getDate(0)
     }
 ]);
+
+export const buildCompareUrl = (baseline_id, system_ids) => {
+
+    let finalUrl = `${ActionTypes.DRIFT_URL}/?baseline_ids=${baseline_id}`;
+
+    system_ids.slice(0, ActionTypes.SYSTEMS_LIMIT).forEach(system_id => {
+        finalUrl = finalUrl.concat(`&system_ids=${system_id}`);
+    });
+
+    return finalUrl;
+};


### PR DESCRIPTION
Previously we were adding only the baseline to the compare table, this PR will add associated system ids to the compare table as well.

We are limiting up to 1 baseline and 4 systems to be added to the drift table.

Added a tooltip to the button as well

Thanks