### PR TITLE
Allow Subscriptions reader to see Subscriptions dashboard widget

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -68,7 +68,8 @@ const App = (props) => {
                         patch: permissionList.includes('patch:*:*'),
                         vulnerability: permissionList.includes('vulnerability:*:*') ||
                             permissionList.includes('vulnerability:vulnerability_results:read'),
-                        subscriptions: permissionList.includes('subscriptions:*:*'),
+                        subscriptions: permissionList.includes('subscriptions:*:*') ||
+                            permissionList.includes('subscriptions:reports:read'),
                         ros: permissionList.includes('ros:*:*') ||
                             permissionList.includes('ros:*:read'),
                         notifications: permissionList.includes('notifications:*:*') ||


### PR DESCRIPTION
Almost a year ago, "Subscriptions user" role was introduced. It included finer-grained permission, `subscriptions:reports:read`. See https://github.com/RedHatInsights/rbac-config/commit/2d8d59e6ed358fda66beb7113c3833e60b53c8a9 . Subscriptions API was modified to recognize this permission in https://github.com/RedHatInsights/rhsm-subscriptions/commit/0426c894f9425dc0e11976b54790f03775ffe6ef . But it looks like we forgot about dashboard card which, so far, recognizes only `subscriptions:*:*`.

`subscriptions:reports:read` is offered through "Subscriptions user" role to all new users since... I don't know, probably sometime around Summit 2021. 