### PR TITLE
Vulnerability card: Fix AAP and MSSQL workload filtering

### DIFF
--- a/src/SmartComponents/Vulnerability/VulnerabilityCard.js
+++ b/src/SmartComponents/Vulnerability/VulnerabilityCard.js
@@ -71,9 +71,9 @@ const VulnerabilityCard = () => {
         const options = {
             ...workloads?.SAP?.isSelected && { sap_system: true },
             ...workloads?.['Ansible Automation Platform']?.isSelected
-                && { ansible: 'not_nil' },
+                && { ansible: 'true' },
             ...workloads?.['Microsoft SQL']?.isSelected
-                && { mssql: 'not_nil' },
+                && { mssql: 'true' },
             ...SID?.length > 0 && { sap_sids: SID },
             ...selectedTags?.length > 0 && { tags: selectedTags }
         };


### PR DESCRIPTION
Resolves [VULN-2489](https://issues.redhat.com/browse/VULN-2489).

Previously if AAP or MSSQL workload was selected the Vulnerability card would not work and would show error message:
` Vulnerability has experienced an error. Contact Red Hat support if the problem persists. `

Fixes API params to be boolean in accordance with [API docs](https://stage.foo.redhat.com:1337/beta/docs/api/vulnerability/v1#operations-default-manager\.dashboard_handler\.GetDashboard\.get).