### PR TITLE
feat(ESSNTL-3964): Adds settings integration button

### DIFF
--- a/build/messages/src/Messages.json
+++ b/build/messages/src/Messages.json
@@ -79,6 +79,10 @@
     "defaultMessage": "{score}% compliant",
     "description": "Compliance - compliant score"
   },
+  "configureIntigrations": {
+    "defaultMessage": "Configure Integrations",
+    "description": "configureIntigrations button label"
+  },
   "contactsales": {
     "defaultMessage": "Contact sales",
     "description": "Contact sales"
@@ -420,15 +424,15 @@
     "description": "Category chart  value"
   },
   "subscriptionsTitle": {
-    "defaultMessage": "Subscription Watch",
+    "defaultMessage": "Subscriptions",
     "description": "Title of the subscriptions utilized card"
   },
   "subscriptionsUtilizedLearnMore": {
-    "defaultMessage": "Activate Subscription Watch to monitor your subscription utilization.",
+    "defaultMessage": "Activate Subscriptions to monitor your subscription utilization.",
     "description": "Subscriptions utilized card - learn more description"
   },
   "subscriptionsUtilizedLearnMoreAction": {
-    "defaultMessage": "Learn about Subscription Watch",
+    "defaultMessage": "Learn about Subscriptions",
     "description": "Subscriptions utilized card - learn more action"
   },
   "subscriptionsUtilizedNoProductData": {
@@ -460,7 +464,7 @@
     "description": "Subscriptions utilized card - product two report total"
   },
   "subscriptionsUtilizedTitle": {
-    "defaultMessage": "Subscription Watch utilization summary",
+    "defaultMessage": "Subscriptions utilization summary",
     "description": "Title of the subscriptions utilized card"
   },
   "systemInventoryCTA": {

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -19,6 +19,7 @@
   "complianceTitle": "Compliance",
   "compliantHostCount": "{count, plural, one {# system} other {# systems}}",
   "compliantScore": "{score}% compliant",
+  "configureIntigrations": "Configure Integrations",
   "contactsales": "Contact sales",
   "critical": "Critical",
   "cveByCvssScoreTitle": "CVEs by CVSS score",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -788,5 +788,10 @@ export default defineMessages({
         id: 'driftCompareTooltip',
         description: 'driftCompareTooltip',
         defaultMessage: 'This will compare the baseline with up to 4 systems'
+    },
+    configureIntegrations: {
+        id: 'configureIntigrations',
+        description: 'configureIntigrations button label',
+        defaultMessage: 'Configure Integrations'
     }
 });

--- a/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
@@ -146,6 +146,16 @@ const SystemInventoryHeader = ({
                         </Flex>
                         <FlexItem align={{ md: 'alignRight' }}>
                             <Button
+                                className='pf-u-mr-sm pf-u-font-size-md'
+                                component='a'
+                                variant='secondary'
+                                isSmall
+                                onClick={e => navigateTo(e, `settings/integrations`)}
+                                href={ `settings/integrations` }
+                            >
+                                { intl.formatMessage(messages.configureIntegrations) }
+                            </Button>
+                            <Button
                                 component='a'
                                 variant='primary'
                                 onClick={e => navigateTo(e, `${UI_BASE}/registration`)}


### PR DESCRIPTION
In accordance to https://issues.redhat.com/browse/ESSNTL-3964 
This PR adds a Configure Integrations button next to the Register Systems button on the dashboard.
To test simply go to the dashboard, verify the button is there, and verify it sends you to` settings/integrations `