### PR TITLE
fix(ESSNTL-3956): remove stale and fresh params from inventory url

### DIFF
--- a/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
@@ -82,7 +82,7 @@ const SystemInventoryHeader = ({
                                 linkDescription={ intl.formatMessage(messages.systemInventoryDescription,
                                     { count: inventorySummary.total || 0 }
                                 ) }
-                                link='./insights/inventory/?status=fresh&status=stale&source=puptoo'
+                                link='./insights/inventory/?source=puptoo'
                             />
                         }
                         {/* {inventoryFetchStatus === 'fulfilled' && inventoryTotalFetchStatus === 'fulfilled' &&


### PR DESCRIPTION
Resolves: [ESSNTL-3956](https://issues.redhat.com/browse/ESSNTL-3956);

Description:
The number of systems is different in the Inventory applcation when navigated from Dashboard 'Systems registered with Insights' link.

To test:

1. Visit dashboard
2. Observe the number of systems that has insights.
3. Click on the link 'Systems registered with Insights' that will bring you to inventory app.
4. Observe the number of systems on the table is the same.