### PR TITLE
fix(/start page): Disable global filter

### DIFF
--- a/src/PresentationalComponents/ZeroState/ZeroState.js
+++ b/src/PresentationalComponents/ZeroState/ZeroState.js
@@ -28,10 +28,10 @@ import IconList from '../IconList/IconList';
 import IconListItem from '../IconList/IconListItem';
 import ImgInsSmartMgmt from '../../images/img__ins-and-sm.png';
 import MarketingBanner from '../MarketingBanner/MarketingBanner';
-import { UI_BASE } from '../../AppConstants';
-import { VULNERABILITIES_CVES_URL } from '../../AppConstants';
+import { UI_BASE, VULNERABILITIES_CVES_URL } from '../../AppConstants';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 // eslint-disable-next-line no-unused-vars
 const SortableTable = () => {
@@ -85,6 +85,15 @@ const SortableTable = () => {
 
 const ZeroState = () => {
     const intl = useIntl();
+    const { hideGlobalFilter } = useChrome();
+
+    useEffect(() => {
+        hideGlobalFilter?.();
+
+        return () => {
+            hideGlobalFilter?.(false);
+        };
+    }, []);
 
     return <div className='insd-c-marketing-page'>
         <MarketingBanner


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-3647.

This disables the global filter on the static /insights/start page.

![image](https://user-images.githubusercontent.com/31385370/211029772-7a0d2cf7-14f9-4e88-9c3a-8c9bdbd71dd9.png)

## How to test

Navigate to /insights/start, and check that the global filter is disabled.