### PR TITLE
Reduce calls to Patch advisories to a single request

### DIFF
--- a/src/AppActions.js
+++ b/src/AppActions.js
@@ -37,19 +37,9 @@ export const patchmanFetchSystems = (options) => ({
     payload: fetchData(ActionTypes.PATCHMAN_SYSTEMS_FETCH_URL, {}, options)
 });
 
-export const patchmanFetchSecurity = (options) => ({
-    type: ActionTypes.PATCHMAN_SECURITY_FETCH,
-    payload: fetchData(ActionTypes.PATCHMAN_SECURITY_FETCH_URL, {}, options)
-});
-
-export const patchmanFetchBugs = (options) => ({
-    type: ActionTypes.PATCHMAN_BUGS_FETCH,
-    payload: fetchData(ActionTypes.PATCHMAN_BUGS_FETCH_URL, {}, options)
-});
-
-export const patchmanFetchEnhancements = (options) => ({
-    type: ActionTypes.PATCHMAN_ENHANCEMENTS_FETCH,
-    payload: fetchData(ActionTypes.PATCHMAN_ENHANCEMENTS_FETCH_URL, {}, options)
+export const patchmanFetchAdvisories = (options) => ({
+    type: ActionTypes.PATCHMAN_ADVISORIES_FETCH,
+    payload: fetchData(ActionTypes.PATCHMAN_ADVISORIES_FETCH_URL, {}, options)
 });
 
 export const subscriptionsUtilizedProductOneFetch = (id, options) => ({

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -35,15 +35,11 @@ export const ADVISOR_INCIDENTS_FETCH_URL = `${BASE_URL}/insights/v1/rule/?impact
 
 // Patchman App Constants
 export const PATCHMAN_ID = 'patch';
-export const PATCHMAN_VER = 'v1';
-export const PATCHMAN_SYSTEMS_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/systems`;
+export const PATCHMAN_VER = 'v2';
+export const PATCHMAN_SYSTEMS_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/systems/?limit=1`;
 export const PATCHMAN_SYSTEMS_FETCH = 'PATCHMAN_SYSTEMS_FETCH';
-export const PATCHMAN_SECURITY_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/advisories?filter[advisory_type]=3&limit=1`;
-export const PATCHMAN_SECURITY_FETCH = 'PATCHMAN_SECURITY_FETCH';
-export const PATCHMAN_BUGS_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/advisories?filter[advisory_type]=2&limit=1`;
-export const PATCHMAN_BUGS_FETCH = 'PATCHMAN_BUGS_FETCH';
-export const PATCHMAN_ENHANCEMENTS_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/advisories/?filter[advisory_type]=1&limit=1`;
-export const PATCHMAN_ENHANCEMENTS_FETCH = 'PATCHMAN_ENHANCEMENTS_FETCH';
+export const PATCHMAN_ADVISORIES_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/advisories/?limit=1`;
+export const PATCHMAN_ADVISORIES_FETCH = 'PATCHMAN_ADVISORIES_FETCH';
 
 // Subscriptions Utilized Constants
 export const SUBSCRIPTIONS_UTILIZED_PRODUCT_ONE_FETCH = 'SUBSCRIPTIONS_UTILIZED_PRODUCT_ONE_FETCH';

--- a/src/AppReducer.js
+++ b/src/AppReducer.js
@@ -17,12 +17,10 @@ const initialState = Immutable({
     advisorIncidentsStatus: '',
     patchmanSystems: {},
     patchmanSystemsStatus: '',
-    patchmanSecurity: {},
-    patchmanSecurityStatus: '',
-    patchmanBugs: {},
-    patchmanBugsStatus: '',
-    patchmanEnhancements: {},
-    patchmanEnhancementsStatus: '',
+    patchmanAdvisoriesStatus: '',
+    patchmanSecurity: '',
+    patchmanBugs: '',
+    patchmanEnhancements: '',
     subscriptionsUtilizedProductOne: [],
     subscriptionsUtilizedProductOneFetchStatus: '',
     subscriptionsUtilizedProductTwo: [],
@@ -121,7 +119,6 @@ export const DashboardStore = (state = initialState, action) => {
         // Patch
         case `${ActionTypes.PATCHMAN_SYSTEMS_FETCH}_PENDING`:
             return state.set('patchmanSystemsStatus', 'pending');
-
         case `${ActionTypes.PATCHMAN_SYSTEMS_FETCH}_FULFILLED`:
             return Immutable.merge(state, {
                 patchmanSystems: action.payload.meta.total_items,
@@ -130,41 +127,15 @@ export const DashboardStore = (state = initialState, action) => {
         case `${ActionTypes.PATCHMAN_SYSTEMS_FETCH}_REJECTED`:
             return state.set('patchmanSystemsStatus', 'rejected');
 
-        case `${ActionTypes.PATCHMAN_SECURITY_FETCH}_PENDING`:
-            return state.set('patchmanSecurityStatus', 'pending');
-
-        case `${ActionTypes.PATCHMAN_SECURITY_FETCH}_FULFILLED`:
+        case `${ActionTypes.PATCHMAN_ADVISORIES_FETCH}_PENDING`:
+            return state.set('patchmanAdvisoriesStatus', 'pending');
+        case `${ActionTypes.PATCHMAN_ADVISORIES_FETCH}_FULFILLED`:
             return Immutable.merge(state, {
-                patchmanSecurity: action.payload.meta.total_items,
-                patchmanSecurityStatus: 'fulfilled'
+                patchmanAdvisories: action.payload.meta.subtotals,
+                patchmanAdvisoriesStatus: 'fulfilled'
             });
-
-        case `${ActionTypes.PATCHMAN_SECURITY_FETCH}_REJECTED`:
-            return state.set('patchmanBugsStatus', 'rejected');
-
-        case `${ActionTypes.PATCHMAN_BUGS_FETCH}_PENDING`:
-            return state.set('patchmanBugsStatus', 'pending');
-
-        case `${ActionTypes.PATCHMAN_BUGS_FETCH}_FULFILLED`:
-            return Immutable.merge(state, {
-                patchmanBugs: action.payload.meta.total_items,
-                patchmanBugsStatus: 'fulfilled'
-            });
-
-        case `${ActionTypes.PATCHMAN_BUGS_FETCH}_REJECTED`:
-            return state.set('patchmanBugsStatus', 'rejected');
-
-        case `${ActionTypes.PATCHMAN_ENHANCEMENTS_FETCH}_PENDING`:
-            return state.set('patchmanEnhancementsStatus', 'pending');
-
-        case `${ActionTypes.PATCHMAN_ENHANCEMENTS_FETCH}_FULFILLED`:
-            return Immutable.merge(state, {
-                patchmanEnhancements: action.payload.meta.total_items,
-                patchmanEnhancementsStatus: 'fulfilled'
-            });
-
-        case `${ActionTypes.PATCHMAN_ENHANCEMENTS_FETCH}_REJECTED`:
-            return state.set('patchmanEnhancementsStatus', 'rejected');
+        case `${ActionTypes.PATCHMAN_ADVISORIES_FETCH}_REJECTED`:
+            return state.set('patchmanAdvisoriesStatus', 'rejected');
 
         // SubsUtilized Product One
         case `${ActionTypes.SUBSCRIPTIONS_UTILIZED_PRODUCT_ONE_FETCH}_PENDING`:

--- a/src/SmartComponents/PatchManager/PatchManagerCard.js
+++ b/src/SmartComponents/PatchManager/PatchManagerCard.js
@@ -31,7 +31,7 @@ const PatchManagerCard = ({
 }) => {
     const intl = useIntl();
     const isLoaded = [systemsStatus, advisoriesStatus].every(item => item === 'fulfilled');
-    const security = advisories.security;
+    const { security, bugfix: bugs, enhancement: enhancements } = advisories || {};
     const bugs = advisories.bugfix;
     const enhancements = advisories.enhancement;
     const pieChartData = [

--- a/src/SmartComponents/PatchManager/PatchManagerCard.js
+++ b/src/SmartComponents/PatchManager/PatchManagerCard.js
@@ -5,7 +5,7 @@ import { PATCHMAN_ID, UI_BASE } from '../../AppConstants';
 import React, { useEffect } from 'react';
 import { TemplateCard, TemplateCardBody, TemplateCardHeader } from '../../PresentationalComponents/Template/TemplateCard';
 import { capitalize, globalFilters, workloadsPropType } from '../../Utilities/Common';
-import { patchmanFetchBugs, patchmanFetchEnhancements, patchmanFetchSecurity, patchmanFetchSystems } from '../../AppActions';
+import { patchmanFetchAdvisories, patchmanFetchSystems } from '../../AppActions';
 
 import { Button } from '@patternfly/react-core/dist/esm/components';
 import { ExpandableCardTemplate } from '../../PresentationalComponents/Template/ExpandableCardTemplate';
@@ -22,13 +22,18 @@ import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 
 /**
- * Operating systems card for showing the ratio of operating systems used.
+ * Card for showing the systems and ratios of current advisories.
  */
-const PatchManagerCard = ({ systems, systemsStatus, fetchSystems, fetchSecurity, securityStatus,
-    security, bugs, fetchBugs, bugsStatus, enhancements, fetchEnhancements, enhancementsStatus,
-    selectedTags, workloads, SID }) => {
+const PatchManagerCard = ({
+    systems, systemsStatus, fetchSystems,
+    advisories, advisoriesStatus, fetchAdvisories,
+    selectedTags, workloads, SID
+}) => {
     const intl = useIntl();
-    const isLoaded = [systemsStatus, securityStatus, bugsStatus, enhancementsStatus].every(item => item === 'fulfilled');
+    const isLoaded = [systemsStatus, advisoriesStatus].every(item => item === 'fulfilled');
+    const security = advisories.security;
+    const bugs = advisories.bugfix;
+    const enhancements = advisories.enhancement;
     const pieChartData = [
         {
             x: intl.formatMessage(messages.securityAdvisories, { count: security }), y: security, fill: chart_color_blue_400.value,
@@ -54,10 +59,8 @@ const PatchManagerCard = ({ systems, systemsStatus, fetchSystems, fetchSecurity,
     useEffect(() => {
         const options = { ...globalFilters(workloads, SID), ...selectedTags?.length > 0 && { tags: selectedTags } };
         fetchSystems(options);
-        fetchSecurity(options);
-        fetchBugs(options);
-        fetchEnhancements(options);
-    }, [fetchSystems, fetchSecurity, fetchBugs, fetchEnhancements, workloads, SID, selectedTags]);
+        fetchAdvisories(options);
+    }, [fetchSystems, fetchAdvisories, workloads, SID, selectedTags]);
 
     if (systemsStatus === 'rejected') {
         return (
@@ -118,15 +121,9 @@ PatchManagerCard.propTypes = {
     systems: PropTypes.any,
     systemsStatus: PropTypes.string,
     fetchSystems: PropTypes.func,
-    fetchSecurity: PropTypes.func,
-    security: PropTypes.any,
-    securityStatus: PropTypes.string,
-    fetchBugs: PropTypes.func,
-    bugs: PropTypes.any,
-    bugsStatus: PropTypes.string,
-    fetchEnhancements: PropTypes.func,
-    enhancements: PropTypes.any,
-    enhancementsStatus: PropTypes.string,
+    advisories: PropTypes.any,
+    advisoriesStatus: PropTypes.string,
+    fetchAdvisories: PropTypes.func,
     selectedTags: PropTypes.arrayOf(PropTypes.string),
     workloads: workloadsPropType,
     SID: PropTypes.arrayOf(PropTypes.string)
@@ -136,20 +133,14 @@ export default connect(
     ({ DashboardStore }) => ({
         systems: DashboardStore.patchmanSystems,
         systemsStatus: DashboardStore.patchmanSystemsStatus,
-        security: DashboardStore.patchmanSecurity,
-        securityStatus: DashboardStore.patchmanSecurityStatus,
-        bugs: DashboardStore.patchmanBugs,
-        bugsStatus: DashboardStore.patchmanBugsStatus,
-        enhancements: DashboardStore.patchmanEnhancements,
-        enhancementsStatus: DashboardStore.patchmanEnhancementsStatus,
+        advisories: DashboardStore.patchmanAdvisories,
+        advisoriesStatus: DashboardStore.patchmanAdvisoriesStatus,
         selectedTags: DashboardStore.selectedTags,
         workloads: DashboardStore.workloads,
         SID: DashboardStore.SID
     }),
     dispatch => ({
         fetchSystems: (options) => dispatch(patchmanFetchSystems(options)),
-        fetchSecurity: (options) => dispatch(patchmanFetchSecurity(options)),
-        fetchBugs: (options) => dispatch(patchmanFetchBugs(options)),
-        fetchEnhancements: (options) => dispatch(patchmanFetchEnhancements(options))
+        fetchAdvisories: (options) => dispatch(patchmanFetchAdvisories(options))
     })
 )(PatchManagerCard);

--- a/src/SmartComponents/PatchManager/PatchManagerCard.js
+++ b/src/SmartComponents/PatchManager/PatchManagerCard.js
@@ -32,8 +32,6 @@ const PatchManagerCard = ({
     const intl = useIntl();
     const isLoaded = [systemsStatus, advisoriesStatus].every(item => item === 'fulfilled');
     const { security, bugfix: bugs, enhancement: enhancements } = advisories || {};
-    const bugs = advisories.bugfix;
-    const enhancements = advisories.enhancement;
     const pieChartData = [
         {
             x: intl.formatMessage(messages.securityAdvisories, { count: security }), y: security, fill: chart_color_blue_400.value,


### PR DESCRIPTION
The subtotals for the three advisory types - bugs, security and enhancements - are available in the `meta` structure of the request. This means that we do not have to make three requests to the Patch API in order to get the data necessary to build the Advisory Types pie chart.

This work basically generates a single request and stores the subtotals data.  The subtotal for each advisory type are then pulled out in the PatchManagerCard component.

Signed-off-by: Paul Wayper <paulway@redhat.com>