### PR TITLE
Remove moment.js library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "https-proxy-agent": "^5.0.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "27.1.0",
-        "moment": "2.29.4",
         "npm-run-all": "4.1.5",
         "prop-types": "15.7.2",
         "qs": "6.10.3",
@@ -14458,15 +14457,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -21025,7 +21015,6 @@
         "filesize": "^3.6.1",
         "lodash": "^4.17.13",
         "mkdirp": "^0.5.1",
-        "moment": "^2.22.1",
         "write-file-atomic": "^2.3.0"
       },
       "engines": {
@@ -32060,12 +32049,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true
-    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -37176,7 +37159,6 @@
         "filesize": "^3.6.1",
         "lodash": "^4.17.13",
         "mkdirp": "^0.5.1",
-        "moment": "^2.22.1",
         "write-file-atomic": "^2.3.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "https-proxy-agent": "^5.0.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "27.1.0",
-    "moment": "2.29.4",
     "npm-run-all": "4.1.5",
     "prop-types": "15.7.2",
     "qs": "6.10.3",

--- a/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.js
+++ b/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedCard.js
@@ -17,6 +17,7 @@ import React, { useEffect, useState } from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
 import { filterChartData, setRangedDateTime } from './SubscriptionsUtilizedHelpers';
 import { supportsGlobalFilter, workloadsPropType } from '../../Utilities/Common';
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
 
 import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
 import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
@@ -30,7 +31,6 @@ import PropTypes from 'prop-types';
 import { TemplateCardBody } from '../../PresentationalComponents/Template/TemplateCard';
 import { connect } from 'react-redux';
 import messages from '../../Messages';
-import moment from 'moment/moment';
 import { useIntl } from 'react-intl';
 
 /**
@@ -101,7 +101,7 @@ const SubscriptionsUtilizedCard = ({ subscriptionsUtilizedProductOne, subscripti
             <li>{intl.formatMessage(messages.subscriptionsUtilizedProductTwoReport, { totalReport: productTwo.report })}</li>
             <li>{intl.formatMessage(messages.subscriptionsUtilizedProductCapacity, { totalCapacity: productTwo.capacity })}</li>
             <li>{intl.formatMessage(messages.subscriptionsUtilizedProductDate,
-                { formattedDate: moment.utc(productTwo.date).format('MMM D, YYYY') })}</li>
+                { formattedDate: <DateFormat type='exact' date={ productTwo.date } /> })}</li>
         </ul>
     );
     const productOneTooltip = (
@@ -109,7 +109,7 @@ const SubscriptionsUtilizedCard = ({ subscriptionsUtilizedProductOne, subscripti
             <li>{intl.formatMessage(messages.subscriptionsUtilizedProductOneReport, { totalReport: productOne.report })}</li>
             <li>{intl.formatMessage(messages.subscriptionsUtilizedProductCapacity, { totalCapacity: productOne.capacity })}</li>
             <li>{intl.formatMessage(messages.subscriptionsUtilizedProductDate,
-                { formattedDate: moment.utc(productOne.date).format('MMM D, YYYY') })}</li>
+                { formattedDate: <DateFormat type='exact' date={ productOne.date } /> })}</li>
         </ul>
     );
 

--- a/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedHelpers.js
+++ b/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedHelpers.js
@@ -1,26 +1,22 @@
-import moment from 'moment';
 import { RHSM_API_RESPONSE_DATA_TYPES } from './Constants';
 
 /**
- * Generate a range of dates.
+ * Generate a range of dates, from the start of 'date' minus 'subtract' days, to the end of 'date'
  *
  * @param {Date} date
  * @param {number} subtract
- * @param {string} measurement
  * @returns {{endDate: Date, startDate: Date}}
  */
-export const setRangedDateTime = (date = new Date(), subtract = 1, measurement = 'days') => ({
-    startDate: moment
-    .utc(date)
-    .startOf(measurement)
-    .subtract(subtract, measurement)
-    .toDate(),
-    endDate: moment
-    .utc(date)
-    .startOf(measurement)
-    .endOf('days')
-    .toDate()
-});
+export const setRangedDateTime = (date = new Date(), subtract = 1) => {
+    if (typeof(date) === 'string') {
+        date = new Date(date);
+    }
+
+    return {
+        startDate: new Date(new Date(date.setUTCHours(0, 0, 0, 0)).setUTCDate(date.getUTCDate() - subtract)),
+        endDate: new Date(date.setUTCHours(23, 59, 59, 999))
+    };
+};
 
 /**
  * Apply a set of schemas using either an array of objects in the

--- a/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedHelpers.test.js
+++ b/src/SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedHelpers.test.js
@@ -3,7 +3,7 @@ import * as RHSM_TYPES from './Constants';
 
 describe('SmartComponents/SubscriptionsUtilized/SubscriptionsUtilizedHelpers', () => {
     it('should return a range of date and time that includes the prior date', () => {
-        expect(setRangedDateTime('20200401')).toMatchSnapshot('date and time');
+        expect(setRangedDateTime('2020-04-01')).toMatchSnapshot('date and time');
     });
 
     it('should return a predictable schema object', () => {


### PR DESCRIPTION
The moment.js library is rather large and some network bandwidth can be saved by removing it from the project.  Its use is only minimal and its use replaced by functions from the built in Date library.