### PR TITLE
fix: Fix the non-working Drift link button

### DIFF
--- a/src/SmartComponents/Drift/DriftEmptyState.js
+++ b/src/SmartComponents/Drift/DriftEmptyState.js
@@ -23,6 +23,7 @@ export const DriftEmptyState = () => {
             </EmptyStateBody>
             <Button
                 href={`${ActionTypes.DRIFT_BASELINES_URL}`}
+                component='a'
                 variant="primary">Go to Baselines
             </Button>
         </EmptyState>


### PR DESCRIPTION
Before, the button didn't behave as a link and didn't do anything after click.

![image](https://user-images.githubusercontent.com/31385370/225346110-ef20855d-c970-4622-b80b-c775b1710211.png)
