### PR TITLE
I do not trust javascript + env truthiness

### DIFF
--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -3,7 +3,7 @@ const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
-    deployment: process.env.BETA ? 'beta/apps' : 'apps',
+    deployment: process.env.BETA === 'true' ? 'beta/apps' : 'apps',
     debug: true
 });
 


### PR DESCRIPTION
We are having a problem at build time where the webpack config is using beta paths even though our env var is set to BETA. I've audited the logs in the build and as far as I can tell everything was correct up to the point where we build dashboard's code, and then it just incorrectly chose beta. I don't *know* if this will fix our issues, but it follows what chrome uses:

https://github.com/RedHatInsights/insights-chrome/blob/e96d6e1801dc11755aabbdf1071fe7969c52de0e/config/webpack.config.js#L26

This is known to work there.