### PR TITLE
Update Patch API to v3

### DIFF
--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -35,7 +35,7 @@ export const ADVISOR_INCIDENTS_FETCH_URL = `${BASE_URL}/insights/v1/rule/?impact
 
 // Patchman App Constants
 export const PATCHMAN_ID = 'patch';
-export const PATCHMAN_VER = 'v2';
+export const PATCHMAN_VER = 'v3';
 export const PATCHMAN_SYSTEMS_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/systems/?limit=1`;
 export const PATCHMAN_SYSTEMS_FETCH = 'PATCHMAN_SYSTEMS_FETCH';
 export const PATCHMAN_ADVISORIES_FETCH_URL = `${BASE_URL}/${PATCHMAN_ID}/${PATCHMAN_VER}/advisories/?limit=1`;

--- a/src/PresentationalComponents/ZeroState/zeroStateConstants.js
+++ b/src/PresentationalComponents/ZeroState/zeroStateConstants.js
@@ -265,7 +265,7 @@ const CONTENT_MANAGEMENT_ZERO_STATE = {
         },
         {
             title: 'Patch APIs',
-            link: 'https://console.redhat.com/docs/api/patch/v2'
+            link: 'https://console.redhat.com/docs/api/patch/v3'
         },
         {
             title: 'Configuring notifications & Integration',


### PR DESCRIPTION
Update Patch API version to fix number mismatch on dashboard and table item count when the number is clicked.

(System count is different when clicked because table shows stale systems by default -- disable stale system filter and the counts will match)

## Before:
![Screenshot from 2023-06-05 23-23-24](https://github.com/RedHatInsights/insights-dashboard/assets/8426204/a40b23cc-3e45-4545-a362-fe9f4b083c11)

## After:
![Screenshot from 2023-06-05 23-23-00](https://github.com/RedHatInsights/insights-dashboard/assets/8426204/26e058d8-e98b-4157-86aa-b5b2fb81d9b8)