### PR TITLE
refactor(ZeroState): Refactor zero state fed mod

### DIFF
--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -120,5 +120,19 @@ NewAppZeroState.propTypes = {
     customFetchResults: propTypes.bool
 };
 AppZeroState.propTypes = {
-    children: propTypes.any
+    children: propTypes.any,
+    app: propTypes.oneOf([
+        'Advisor',
+        'Compliance',
+        'Drift',
+        'Insights',
+        'Content_management',
+        'Policies',
+        'Malware',
+        'Resource_optimization',
+        'Vulnerability',
+        'Images',
+        'Remediations',
+        'Inventory',
+        'Tasks'])
 };

--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -1,13 +1,83 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import AppSection from './AppSection';
 import ZeroStateBanner from './ZeroStateBanner';
 import ZeroStateFooter from './ZeroStateFooter';
 import propTypes from 'prop-types';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 
-const AppZeroState = ({ app, customInstructions, customButton, customText, customTitle,
-    appId }) => {
+//current stand in as we migrate away from the old version
+const AppZeroState = ({ children, ...props }) => {
+    return (children ? <NewAppZeroState {...props}>{children}</NewAppZeroState> : <OldAppZeroState {...props} />);
+};
 
+const standardApiReq = '/api/inventory/v1/hosts?page=1&per_page=1';
+
+const NewAppZeroState = ({
+    app,
+    customInstructions,
+    customButton,
+    customText,
+    customTitle,
+    appId,
+    children,
+    customFetchResults
+}) => {
+    const axios = useAxiosWithPlatformInterceptors();
+    const [hasSystems, setHasSystems] = useState(true);
+    const mounted = useRef(false);
+    useEffect(() => {
+        mounted.current = true;
+        const fetchData =  async () => {
+            //if you pass custom fetch, dont use standard at all
+            try {
+                if (customFetchResults !== undefined) {
+                    mounted.current && setHasSystems(customFetchResults);
+                } else {
+                    axios.get(`${standardApiReq}`)
+                    .then(({ data }) => {
+                        mounted.current && setHasSystems(data.total > 0);
+                    });
+                }
+            } catch (e) {
+                console.log(e);
+            }};
+
+        fetchData();
+        return () => {
+            mounted.current = false;
+        };
+    }, [axios, customFetchResults, hasSystems]);
+
+    return (
+        //If hasSystems is true, render routes
+        hasSystems ? children :
+            <IntlProvider>
+                <React.Fragment>
+                    <ZeroStateBanner
+                        appName={app}
+                        customInstructions={customInstructions}
+                        customButton={customButton}
+                        customText={customText}
+                        customTitle={customTitle}
+                        appId={appId}
+                    />
+                    <AppSection appName={app}/>
+                    <ZeroStateFooter appName={app} />
+                </React.Fragment>
+            </IntlProvider>
+    );
+};
+
+//We will slowly migrate away from this
+const OldAppZeroState = ({
+    app,
+    customInstructions,
+    customButton,
+    customText,
+    customTitle,
+    appId
+}) => {
     return (
         <IntlProvider>
             <React.Fragment>
@@ -28,11 +98,27 @@ const AppZeroState = ({ app, customInstructions, customButton, customText, custo
 
 export default AppZeroState;
 
-AppZeroState.propTypes = {
+OldAppZeroState.propTypes = {
     app: propTypes.string,
     customInstructions: propTypes.any,
     customButton: propTypes.any,
     customText: propTypes.string,
     customTitle: propTypes.string,
-    appId: propTypes.string
+    appId: propTypes.string,
+    children: propTypes.any,
+    fetchSystem: propTypes.bool
+};
+
+NewAppZeroState.propTypes = {
+    app: propTypes.string,
+    customInstructions: propTypes.any,
+    customButton: propTypes.any,
+    customText: propTypes.string,
+    customTitle: propTypes.string,
+    appId: propTypes.string,
+    children: propTypes.any,
+    customFetchResults: propTypes.bool
+};
+AppZeroState.propTypes = {
+    children: propTypes.any
 };


### PR DESCRIPTION
This refactor allows us to move the logic from zero state federated module, into the module itself so that apps are cleaner and there is one source of truth.
This also allows for custom fetch conditionals. The app can do its own logic and pass the result of that into customFetchResults and it will set the zero state to true or false depending on the value passed in.
This also allows the clean up up code in the router section of apps so that in that section, isntead of the conditional currently it apps it would look something like this `<AppZeroState app={'advisor'} customFetchResults={true}>
            <Suspense fallback={<Loading />}>
                <Routes>
                    <Route path='/start' element={<ZeroState />} />
                    <Route path='/*' element={<Dashboard />} />
                </Routes>
            </Suspense>
        </AppZeroState>`
        
Lastly this refactor allows us to maintain the current version of zero state that apps have while we slowly migrate over.


To test this refactor replace the code in DashoardRoutes with the example I pasted here. Play with the customFetchResults as you like.