### PR TITLE
refactor(RHINENG-8815): Refactor to reduce api calls

### DIFF
--- a/config/overrideChrome.js
+++ b/config/overrideChrome.js
@@ -6,5 +6,24 @@ export default () => ({
     on: () => {},
     getApp: () => 'dashboard',
     getBundle: () => 'insights',
-    getUserPermissions: () => [{ permission: 'inventory:*:*' }]
+    getUserPermissions: () => [{ permission: 'inventory:*:*' }],
+    analytics: {
+        track: () => fetch('/analytics/track')
+    },
+    auth: {
+        getUser: () => Promise.resolve(true),
+        logout: () => Promise.resolve(true)
+    }
+});
+
+export const useChrome = () => ({
+    updateDocumentTitle: () => undefined,
+    isBeta: () => false,
+    analytics: {
+        track: () => fetch('/analytics/track')
+    },
+    auth: {
+        getUser: () => Promise.resolve(true),
+        logout: () => Promise.resolve(true)
+    }
 });

--- a/src/App.js
+++ b/src/App.js
@@ -31,8 +31,6 @@ const App = (props) => {
     const [hasSystems, setHasSystems] = useState();
 
     async function initChrome() {
-        chrome.identifyApp('dashboard');
-
         chrome?.globalFilterScope?.('insights');
         if (chrome?.globalFilterScope) {
             chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {

--- a/src/PresentationalComponents/Dashboard/Dashboard.js
+++ b/src/PresentationalComponents/Dashboard/Dashboard.js
@@ -40,69 +40,71 @@ const Dashboard = (/*{ workloads }*/) => {
         chrome.updateDocumentTitle(`Dashboard | Red Hat Insights`);
     }, [chrome]);
 
-    return permission.hasSystems  ?
-        <React.Fragment>
-            <PageSection isWidthLimited variant={ PageSectionVariants.light } className="insd-c-dashboard-header">
-                <Title headingLevel="h1" size="2xl" className="pf-v5-u-screen-reader">
-                    {intl.formatMessage(messages.dashboardTitle)}
-                </Title>
-                <Suspense fallback={ <Loading /> }>
-                    <SystemInventoryHeader />
-                </Suspense>
-            </PageSection>
-            <PageSection isFilled={true} isWidthLimited>
-                <Grid hasGutter>
+    return permission.hasSystems === 'undefined' ?
+        <Loading/> :
+        permission.hasSystems  ?
+            <React.Fragment>
+                <PageSection isWidthLimited variant={ PageSectionVariants.light } className="insd-c-dashboard-header">
+                    <Title headingLevel="h1" size="2xl" className="pf-v5-u-screen-reader">
+                        {intl.formatMessage(messages.dashboardTitle)}
+                    </Title>
                     <Suspense fallback={ <Loading /> }>
-                        {newRules?.length > 0 && permission.vulnerability && <GridItem>
-                            <NewRules />
-                        </GridItem> }
+                        <SystemInventoryHeader/>
                     </Suspense>
-                    <Masonry
-                        breakpointCols={breakpointColumnsObj}
-                        className="ins-l-masonry"
-                        columnClassName="ins-l-masonry_column"
-                    >
+                </PageSection>
+                <PageSection isFilled={true} isWidthLimited>
+                    <Grid hasGutter>
                         <Suspense fallback={ <Loading /> }>
-                            {permission.vulnerability &&
+                            {newRules?.length > 0 && permission.vulnerability && <GridItem>
+                                <NewRules />
+                            </GridItem> }
+                        </Suspense>
+                        <Masonry
+                            breakpointCols={breakpointColumnsObj}
+                            className="ins-l-masonry"
+                            columnClassName="ins-l-masonry_column"
+                        >
+                            <Suspense fallback={ <Loading /> }>
+                                {permission.vulnerability &&
                                 <VulnerabilityCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.advisor &&
+                                }
+                            </Suspense>
+                            <Suspense fallback={ <Loading /> }>
+                                {permission.advisor &&
                                 <AdvisorCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.compliance &&
+                                }
+                            </Suspense>
+                            <Suspense fallback={ <Loading /> }>
+                                {permission.compliance &&
                                 <ComplianceCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.remediations &&
+                                }
+                            </Suspense>
+                            <Suspense fallback={ <Loading /> }>
+                                {permission.remediations &&
                                 <RemediationsCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.patch &&
+                                }
+                            </Suspense>
+                            <Suspense fallback={ <Loading /> }>
+                                {permission.patch &&
                                 <PatchManagerCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.ros &&
+                                }
+                            </Suspense>
+                            <Suspense fallback={ <Loading /> }>
+                                {permission.ros &&
                                 <ResourceOptimizationCard/>
-                            }
-                        </Suspense>
-                        <Suspense>
-                            {permission.drift && permission.notifications
+                                }
+                            </Suspense>
+                            <Suspense>
+                                {permission.drift && permission.notifications
                             && <DriftCard/>}
-                        </Suspense>
-                    </Masonry>
-                </Grid>
-            </PageSection>
-            <Footer supportsSap={ true }/>
-        </React.Fragment>
-        :
-        <ZeroState/>;
+                            </Suspense>
+                        </Masonry>
+                    </Grid>
+                </PageSection>
+                <Footer supportsSap={ true }/>
+            </React.Fragment>
+            :
+            <ZeroState/>;
 
 };
 

--- a/src/PresentationalComponents/Dashboard/Dashboard.js
+++ b/src/PresentationalComponents/Dashboard/Dashboard.js
@@ -40,71 +40,69 @@ const Dashboard = (/*{ workloads }*/) => {
         chrome.updateDocumentTitle(`Dashboard | Red Hat Insights`);
     }, [chrome]);
 
-    return permission.hasSystems === 'undefined' ?
-        <Loading/> :
-        permission.hasSystems  ?
-            <React.Fragment>
-                <PageSection isWidthLimited variant={ PageSectionVariants.light } className="insd-c-dashboard-header">
-                    <Title headingLevel="h1" size="2xl" className="pf-v5-u-screen-reader">
-                        {intl.formatMessage(messages.dashboardTitle)}
-                    </Title>
+    return permission.hasSystems  ?
+        <React.Fragment>
+            <PageSection isWidthLimited variant={ PageSectionVariants.light } className="insd-c-dashboard-header">
+                <Title headingLevel="h1" size="2xl" className="pf-v5-u-screen-reader">
+                    {intl.formatMessage(messages.dashboardTitle)}
+                </Title>
+                <Suspense fallback={ <Loading /> }>
+                    <SystemInventoryHeader/>
+                </Suspense>
+            </PageSection>
+            <PageSection isFilled={true} isWidthLimited>
+                <Grid hasGutter>
                     <Suspense fallback={ <Loading /> }>
-                        <SystemInventoryHeader/>
+                        {newRules?.length > 0 && permission.vulnerability && <GridItem>
+                            <NewRules />
+                        </GridItem> }
                     </Suspense>
-                </PageSection>
-                <PageSection isFilled={true} isWidthLimited>
-                    <Grid hasGutter>
+                    <Masonry
+                        breakpointCols={breakpointColumnsObj}
+                        className="ins-l-masonry"
+                        columnClassName="ins-l-masonry_column"
+                    >
                         <Suspense fallback={ <Loading /> }>
-                            {newRules?.length > 0 && permission.vulnerability && <GridItem>
-                                <NewRules />
-                            </GridItem> }
-                        </Suspense>
-                        <Masonry
-                            breakpointCols={breakpointColumnsObj}
-                            className="ins-l-masonry"
-                            columnClassName="ins-l-masonry_column"
-                        >
-                            <Suspense fallback={ <Loading /> }>
-                                {permission.vulnerability &&
+                            {permission.vulnerability &&
                                 <VulnerabilityCard />
-                                }
-                            </Suspense>
-                            <Suspense fallback={ <Loading /> }>
-                                {permission.advisor &&
+                            }
+                        </Suspense>
+                        <Suspense fallback={ <Loading /> }>
+                            {permission.advisor &&
                                 <AdvisorCard />
-                                }
-                            </Suspense>
-                            <Suspense fallback={ <Loading /> }>
-                                {permission.compliance &&
+                            }
+                        </Suspense>
+                        <Suspense fallback={ <Loading /> }>
+                            {permission.compliance &&
                                 <ComplianceCard />
-                                }
-                            </Suspense>
-                            <Suspense fallback={ <Loading /> }>
-                                {permission.remediations &&
+                            }
+                        </Suspense>
+                        <Suspense fallback={ <Loading /> }>
+                            {permission.remediations &&
                                 <RemediationsCard />
-                                }
-                            </Suspense>
-                            <Suspense fallback={ <Loading /> }>
-                                {permission.patch &&
+                            }
+                        </Suspense>
+                        <Suspense fallback={ <Loading /> }>
+                            {permission.patch &&
                                 <PatchManagerCard />
-                                }
-                            </Suspense>
-                            <Suspense fallback={ <Loading /> }>
-                                {permission.ros &&
+                            }
+                        </Suspense>
+                        <Suspense fallback={ <Loading /> }>
+                            {permission.ros &&
                                 <ResourceOptimizationCard/>
-                                }
-                            </Suspense>
-                            <Suspense>
-                                {permission.drift && permission.notifications
+                            }
+                        </Suspense>
+                        <Suspense>
+                            {permission.drift && permission.notifications
                             && <DriftCard/>}
-                            </Suspense>
-                        </Masonry>
-                    </Grid>
-                </PageSection>
-                <Footer supportsSap={ true }/>
-            </React.Fragment>
-            :
-            <ZeroState/>;
+                        </Suspense>
+                    </Masonry>
+                </Grid>
+            </PageSection>
+            <Footer supportsSap={ true }/>
+        </React.Fragment>
+        :
+        <ZeroState/>;
 
 };
 

--- a/src/PresentationalComponents/ZeroState/ZeroState.js
+++ b/src/PresentationalComponents/ZeroState/ZeroState.js
@@ -192,7 +192,7 @@ const ZeroState = () => {
             </Grid>
         </PageSection>
         <MarketingBanner
-            isWidthLimited='true'
+            isWidthLimited={true}
             hasGraphic
             graphicRight
             dark1000

--- a/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
@@ -5,7 +5,7 @@ import {
     Flex,
     FlexItem
 } from '@patternfly/react-core/dist/esm/layouts';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { workloadsPropType } from '../../Utilities/Common';
 
 // components
@@ -42,7 +42,13 @@ const SystemInventoryHeader = ({
         'inventory:hosts:*',
         'inventory:hosts:read'
     ]);
-    const [isLoading, inventorySummary, inventoryWarningSummary, error] = useBatchInventoryFetch(workloads, SID, selectedTags);
+
+    const [
+        isLoading,
+        inventorySummary,
+        inventoryWarningSummary,
+        inventoryStaleSum,
+        error] = useBatchInventoryFetch(workloads, SID, selectedTags, hasAccess);
 
     const intl = useIntl();
 
@@ -98,7 +104,7 @@ const SystemInventoryHeader = ({
                                             className="pf-v5-c-button pf-m-link pf-m-inline">
                                             <IconInline
                                                 message={ intl.formatMessage(messages.systemInventoryStale,
-                                                    { count: inventorySummary.total || 0 }
+                                                    { count: inventoryStaleSum.total || 0 }
                                                 ) }
                                                 state="warning"
                                                 systemInventory

--- a/src/Utilities/useBatchInventoryFetch.js
+++ b/src/Utilities/useBatchInventoryFetch.js
@@ -1,14 +1,15 @@
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { useEffect, useRef, useState } from 'react';
-import { INVENTORY_FETCH_URL, INVENTORY_WARNING_FETCH_URL } from '../AppConstants';
+import { INVENTORY_FETCH_URL, INVENTORY_STALE_FETCH_URL, INVENTORY_WARNING_FETCH_URL } from '../AppConstants';
 import { globalFilters } from './Common';
 
-export const useBatchInventoryFetch = (workloads, SID, selectedTags) => {
+export const useBatchInventoryFetch = (workloads, SID, selectedTags, hasAccess) => {
     const axios = useAxiosWithPlatformInterceptors();
     const mounted = useRef(false);
     const [isLoading, setIsLoading] = useState(true);
     const [inventorySummary, setInventorySummary] = useState();
     const [inventoryWarningSummary, setInventoryWarningSummary] = useState();
+    const [inventoryStaleSum, setInventoryStaleSum] = useState();
     const [error, setError] = useState(false);
 
     useEffect(() => {
@@ -20,11 +21,15 @@ export const useBatchInventoryFetch = (workloads, SID, selectedTags) => {
                 setIsLoading(true);
                 const inventorySum = options !== 'undefined' && await axios.get(`${INVENTORY_FETCH_URL}`, { params: { ...options } });
                 const inventoryWarningSum = options !== 'undefined' && await axios.get(`${INVENTORY_WARNING_FETCH_URL}`, { params: { ...options } });
+                const inventoryStaleSum = options !== 'undefined' && await axios.get(`${INVENTORY_STALE_FETCH_URL}`, { params: { ...options } });
+
                 mounted.current &&
                     (
-                        setIsLoading(false),
                         setInventorySummary(inventorySum),
-                        setInventoryWarningSummary(inventoryWarningSum)
+                        setInventoryWarningSummary(inventoryWarningSum),
+                        setInventoryStaleSum(inventoryStaleSum),
+                        setIsLoading(false)
+
                     );
             } catch (err) {
                 console.error(err);
@@ -32,11 +37,16 @@ export const useBatchInventoryFetch = (workloads, SID, selectedTags) => {
             }
         };
 
-        fetchData();
+        hasAccess === true && fetchData();
         return () => {
             mounted.current = false;
         };
-    }, [workloads, SID, selectedTags]);
+    }, [workloads, SID, selectedTags, hasAccess]);
 
-    return [isLoading, inventorySummary, inventoryWarningSummary, error];
+    return [
+        isLoading,
+        inventorySummary,
+        inventoryWarningSummary,
+        inventoryStaleSum,
+        error];
 };

--- a/src/Utilities/useBatchInventoryFetch.js
+++ b/src/Utilities/useBatchInventoryFetch.js
@@ -1,0 +1,42 @@
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import { useEffect, useRef, useState } from 'react';
+import { INVENTORY_FETCH_URL, INVENTORY_WARNING_FETCH_URL } from '../AppConstants';
+import { globalFilters } from './Common';
+
+export const useBatchInventoryFetch = (workloads, SID, selectedTags) => {
+    const axios = useAxiosWithPlatformInterceptors();
+    const mounted = useRef(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [inventorySummary, setInventorySummary] = useState();
+    const [inventoryWarningSummary, setInventoryWarningSummary] = useState();
+    const [error, setError] = useState(false);
+
+    useEffect(() => {
+        //add options to url
+        const options = { ...globalFilters(workloads, SID), ...selectedTags?.length > 0 && { tags: selectedTags } };
+        mounted.current = true;
+        const fetchData = async () => {
+            try {
+                setIsLoading(true);
+                const inventorySum = options !== 'undefined' && await axios.get(`${INVENTORY_FETCH_URL}`, { params: { ...options } });
+                const inventoryWarningSum = options !== 'undefined' && await axios.get(`${INVENTORY_WARNING_FETCH_URL}`, { params: { ...options } });
+                mounted.current &&
+                    (
+                        setIsLoading(false),
+                        setInventorySummary(inventorySum),
+                        setInventoryWarningSummary(inventoryWarningSum)
+                    );
+            } catch (err) {
+                console.error(err);
+                setError(true);
+            }
+        };
+
+        fetchData();
+        return () => {
+            mounted.current = false;
+        };
+    }, [workloads, SID, selectedTags]);
+
+    return [isLoading, inventorySummary, inventoryWarningSummary, error];
+};


### PR DESCRIPTION
Navigate to the dashboards page, open up the network tab and filter got /host request.
In master, every other refresh will result in 22 calls when you clear or add a global filter. With this refactor is should be around 14.

Further work can be done for improvements. The currently global filters are 'updating' every time a file contains the connect function for the dashboard store. (5 files). Investigation into that would be the next step