### PR TITLE
feat(RHINENG-8918): Add CentOS card to the main dashboard

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -31,6 +31,7 @@ globals:
   render: true
   shallow: true
   React: true
+  jest: true
 rules:
   no-console: 1
   array-bracket-spacing: 2

--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,1 +1,4 @@
 
+import { jest } from '@jest/globals';
+
+global.jest = jest;

--- a/package.json
+++ b/package.json
@@ -54,9 +54,7 @@
     "setupFiles": [
       "<rootDir>/config/setupTests.js"
     ],
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(@patternfly/react-core/|@patternfly/react-tokens/|@patternfly/react-icons/|@patternfly/react-charts/)).*$"
-    ],
+    "transformIgnorePatterns": [],
     "testEnvironment": "jsdom"
   },
   "dependencies": {

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -59,6 +59,7 @@ export const INVENTORY_STALE_FETCH = 'INVENTORY_STALE_FETCH';
 export const INVENTORY_STALE_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?staleness=stale&registered_with=puptoo&${INVENTORY_CONVENTIONAL_FILTER}&${INVENTORY_PER_PAGE}`;
 export const INVENTORY_WARNING_FETCH = 'INVENTORY_WARNING_FETCH';
 export const INVENTORY_WARNING_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?staleness=stale_warning&registered_with=puptoo&${INVENTORY_CONVENTIONAL_FILTER}&${INVENTORY_PER_PAGE}`;
+export const INVENTORY_CENTOS_FETCH_URL = `${BASE_URL}${INVENTORY_BASE}/hosts?per_page=1&page=1&filter[system_profile][operating_system][CentOS Linux][version][gte]=0`;
 
 // Edge constants
 export const EDGE_BASE = '/edge/v1';

--- a/src/PresentationalComponents/Dashboard/Dashboard.js
+++ b/src/PresentationalComponents/Dashboard/Dashboard.js
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import { workloadsPropType } from '../../Utilities/Common';
 import ResourceOptimizationCard from '../../SmartComponents/ResourceOptimization/ResourceOptimizationCard';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { CentOsCard } from '../../SmartComponents/CentOs';
 
 const AdvisorCard = lazy(() => import('../../SmartComponents/Advisor/Advisor'));
 const ComplianceCard = lazy(() => import('../../SmartComponents/Compliance/ComplianceCard'));
@@ -77,6 +78,7 @@ const Dashboard = (/*{ workloads }*/) => {
                                 <ComplianceCard />
                             }
                         </Suspense>
+                        <CentOsCard />
                         <Suspense fallback={ <Loading /> }>
                             {permission.remediations &&
                                 <RemediationsCard />

--- a/src/PresentationalComponents/DownloadReport/DownloadReport.js
+++ b/src/PresentationalComponents/DownloadReport/DownloadReport.js
@@ -1,6 +1,6 @@
 import './DownloadReport.scss';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button } from '@patternfly/react-core';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import React from 'react';
 

--- a/src/PresentationalComponents/Template/ExpandableCardTemplate.js
+++ b/src/PresentationalComponents/Template/ExpandableCardTemplate.js
@@ -1,4 +1,4 @@
-import { Card, CardExpandableContent, CardHeader, CardTitle, Divider, Title } from '@patternfly/react-core/dist/esm/components';
+import { Card, CardExpandableContent, CardHeader, CardTitle, Divider, Title } from '@patternfly/react-core';
 import React, { useState } from 'react';
 
 import propTypes from 'prop-types';

--- a/src/SmartComponents/CentOs/CentOsCard.js
+++ b/src/SmartComponents/CentOs/CentOsCard.js
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Bullseye,
+    Button,
+    Flex,
+    FlexItem,
+    Spinner,
+    Text,
+    TextContent,
+    Title
+} from '@patternfly/react-core';
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import { INVENTORY_CENTOS_FETCH_URL } from '../../AppConstants';
+import { ExpandableCardTemplate } from '../../PresentationalComponents/Template/ExpandableCardTemplate';
+import { TemplateCardBody } from '../../PresentationalComponents/Template/TemplateCard';
+import { EOLCountdownAlert } from './EOLCountdownAlert';
+
+const CentOsCard = () => {
+    const axios = useAxiosWithPlatformInterceptors();
+    const navigate = useInsightsNavigate('tasks');
+    const [totalCentOsHosts, setTotalCentOsHosts] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const hasCentOsHosts = totalCentOsHosts !== null && totalCentOsHosts > 0;
+
+    useEffect(() => {
+        const getCentOsCount = async () => {
+            const response = await axios.get(INVENTORY_CENTOS_FETCH_URL);
+
+            setTotalCentOsHosts(response.total);
+            setIsLoading(false);
+        };
+
+        getCentOsCount();
+    }, []);
+
+    return (
+        <ExpandableCardTemplate
+            appName="tasks"
+            className="centos-warning"
+            title="Convert your CentOS systems to RHEL"
+            body={
+                <TemplateCardBody>
+                    <Flex direction={{ default: 'column' }} gap={{ default: 'gapLg' }}>
+                        <FlexItem>
+                            <EOLCountdownAlert />
+                        </FlexItem>
+                        {isLoading && (
+                            <Bullseye>
+                                <Spinner aria-label='Loading CentOS hosts'/>
+                            </Bullseye>
+                        )}
+                        {(!isLoading && hasCentOsHosts) && (
+                            <FlexItem>
+                                <Flex
+                                    direction={{ default: 'column' }}
+                                    alignItems={{ default: 'alignItemsCenter' }}
+                                    gap={{ default: 'gapMd' }}
+                                >
+                                    <Title headingLevel="h3" size="2xl">
+                                        {totalCentOsHosts} CentOS systems
+                                    </Title>
+                                    <Text component="p" style={{ textAlign: 'center' }}>
+                                        Detected on your system and ready for pre-conversion
+                                        analysis and conversion to RHEL.
+                                    </Text>
+                                    <Text component="p" style={{ textAlign: 'center' }}>
+                                        <a
+                                            href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                        >
+                                            Learn more
+                                        </a>{' '}
+                                        about migrating your CentOS Linux systems to RHEL, whether
+                                        on-premise or in the cloud
+                                    </Text>
+                                    <FlexItem>
+                                        <Button
+                                            variant="secondary"
+                                            onClick={() =>
+                                                navigate('/available/convert-to-rhel-preanalysis')
+                                            }
+                                        >
+                                            Start converting CentOS systems
+                                        </Button>
+                                    </FlexItem>
+                                </Flex>
+                            </FlexItem>
+                        )}
+                        {(!isLoading && !hasCentOsHosts) && (
+                            <>
+                                <FlexItem>
+                                    <TextContent>
+                                        <Text component="p">
+                                            On June 30, 2024, CentOS Linux 7 will reach End of Life
+                                            (EOL), and those systems will stop receiving updates,
+                                            security patches, and new features.
+                                        </Text>
+                                        <Text component="p">
+                                            Red Hat can help.{' '}
+                                            <a
+                                                href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration"
+                                                target="_blank"
+                                                rel="noreferrer"
+                                            >
+                                                Learn more
+                                            </a>{' '}
+                                            about migrating your CentOS Linux systems to RHEL, whether
+                                            on-premise or in the cloud
+                                        </Text>
+                                    </TextContent>
+                                </FlexItem>
+                                <FlexItem>
+                                    <Button
+                                        variant="secondary"
+                                        onClick={() =>
+                                            navigate('/available/convert-to-rhel-preanalysis')
+                                        }
+                                    >
+                                        Start converting CentOS systems
+                                    </Button>
+                                </FlexItem>
+                            </>
+                        )}
+                    </Flex>
+                </TemplateCardBody>
+            }
+        />
+    );
+};
+
+export default CentOsCard;
+export { CentOsCard };

--- a/src/SmartComponents/CentOs/CentOsCard.js
+++ b/src/SmartComponents/CentOs/CentOsCard.js
@@ -25,9 +25,14 @@ const CentOsCard = () => {
 
     useEffect(() => {
         const getCentOsCount = async () => {
-            const response = await axios.get(INVENTORY_CENTOS_FETCH_URL);
+            try {
+                const response = await axios.get(INVENTORY_CENTOS_FETCH_URL);
 
-            setTotalCentOsHosts(response.total);
+                setTotalCentOsHosts(response.total);
+            } catch (error) {
+                setTotalCentOsHosts(0);
+            }
+
             setIsLoading(false);
         };
 

--- a/src/SmartComponents/CentOs/CentOsCard.test.js
+++ b/src/SmartComponents/CentOs/CentOsCard.test.js
@@ -12,7 +12,6 @@ jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors', (
     }))
 }));
 jest.mock('@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate');
-jest.mock('@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate');
 
 describe('CentOsCard', () => {
     it('renders loading state first',  () => {

--- a/src/SmartComponents/CentOs/CentOsCard.test.js
+++ b/src/SmartComponents/CentOs/CentOsCard.test.js
@@ -1,0 +1,98 @@
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import CentOsCard from './CentOsCard';
+
+jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors', () => ({
+    useAxiosWithPlatformInterceptors: jest.fn(() => ({
+        get: () => new Promise(() => {})
+    }))
+}));
+jest.mock('@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate');
+jest.mock('@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate');
+
+describe('CentOsCard', () => {
+    it('renders loading state first',  () => {
+        render(<CentOsCard />);
+
+        screen.getByRole('progressbar', {
+            name: /loading centos hosts/i
+        });
+
+    });
+
+    it('renders alert after eol', () => {
+        jest.useFakeTimers('modern');
+        jest.setSystemTime(new Date('July 15, 2024'));
+        render(<CentOsCard />);
+
+        screen.getByRole('heading', {
+            name: /centos 7 has reached end of life/i
+        });
+
+        jest.useRealTimers(); // reset the mocked date
+    });
+
+    it('renders before eol', () => {
+        jest.useFakeTimers('modern');
+        jest.setSystemTime(new Date('May 15, 2024'));
+        render(<CentOsCard />);
+
+        screen.getByRole('heading', {
+            name: /centos 7 reaches end of life \(eol\) in \d+ days/i
+        });
+
+        jest.useRealTimers(); // reset the mocked date
+    });
+
+    it('renders default text when no centos systems', async () => {
+        useAxiosWithPlatformInterceptors.mockReturnValue({
+            get: () => ({ total: 0 })
+        });
+        render(<CentOsCard />);
+
+        await waitFor(()=>{
+            screen.getByText(
+                /on june 30, 2024, centos linux 7 will reach end of life/i
+            );
+        });
+        expect(screen.getByRole('link', {
+            name: /learn more/i
+        })).toHaveAttribute('href', 'https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration');
+    });
+
+    it('renders hosts count when centos systems present', async () => {
+        useAxiosWithPlatformInterceptors.mockReturnValue({
+            get: () => ({ total: 5 })
+        });
+        render(<CentOsCard />);
+
+        await waitFor(()=>{
+            screen.getByRole('heading', {
+                name: /5 centos systems/i
+            });
+        });
+        screen.getByText(
+            /detected on your system and ready for pre-conversion analysis and conversion to rhel\./i
+        );
+    });
+
+    it('shows pre-conversion task button', async () => {
+        const navigateFn = jest.fn();
+        useInsightsNavigate.mockReturnValue(navigateFn);
+        render(<CentOsCard />);
+
+        await waitFor(()=>{
+            screen.getByRole('button', {
+                name: /start converting centos systems/i
+            });
+        });
+        await userEvent.click(screen.getByRole('button', {
+            name: /start converting centos systems/i
+        }));
+        expect(navigateFn).toBeCalledWith('/available/convert-to-rhel-preanalysis');
+    });
+});

--- a/src/SmartComponents/CentOs/EOLCountdownAlert.js
+++ b/src/SmartComponents/CentOs/EOLCountdownAlert.js
@@ -1,0 +1,26 @@
+import { Alert } from '@patternfly/react-core';
+import React from 'react';
+
+const CentOSEOLDate = 'June 30, 2024';
+
+const getDaysLeft = (untilDate) => {
+    let timeDiff = new Date(untilDate).getTime() - new Date().getTime();
+
+    return Math.ceil(timeDiff / (1000 * 3600 * 24));
+};
+
+const EOLCountdownAlert = () => {
+    const daysLeft = getDaysLeft(CentOSEOLDate);
+    const preTitle = `CentOS 7 reaches End of Life (EOL) in ${daysLeft} days`;
+    const postTitle = 'CentOS 7 has reached End of Life (EOL)';
+
+    return (
+        <Alert
+            variant={daysLeft > 0 ? 'warning' : 'danger'}
+            title={daysLeft > 0 ? preTitle : postTitle}
+            isInline
+        />
+    );
+};
+
+export { EOLCountdownAlert, CentOSEOLDate };

--- a/src/SmartComponents/CentOs/index.js
+++ b/src/SmartComponents/CentOs/index.js
@@ -1,0 +1,2 @@
+export { CentOsCard } from './CentOsCard';
+export { EOLCountdownAlert } from './EOLCountdownAlert';


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-8918.

Based on https://github.com/RedHatInsights/insights-dashboard/pull/480.

This adds a new widget to the main dashboard that alerts about CentOS upcoming EOL and also shows additional links, hosts count, etc.

## How to test

1. Go to the dashboard
2. If your account has zero CentOS systems, the widget should show the alert, text with links and the button redirecting to the Tasks app
3. If you account has at least one CentOS systems, the widget should also show the CentOS hosts count
4. The widget should always be shown

## Screenshots

<img width="905" alt="image" src="https://github.com/RedHatInsights/insights-dashboard/assets/31385370/0112b402-7d34-4178-9e9f-69e393f92cfd">
