### PR TITLE
fix(RHINENG-9846): do not show zero-state while loading data

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -2,3 +2,16 @@
 import { jest } from '@jest/globals';
 
 global.jest = jest;
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+    __esModule: true,
+    default: () => ({
+        getUserPermissions: () => Promise.resolve(['inventory:*:*']),
+        hideGlobalFilter: () => jest.fn(),
+        getBundle: jest.fn()
+    }),
+    useChrome: () => ({
+        isBeta: jest.fn(),
+        updateDocumentTitle: jest.fn()
+    })
+}));

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import './App.scss';
 
-import React, { createContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { setSIDs, setSelectedTags, setWorkloads } from './AppActions';
 
@@ -9,30 +9,16 @@ import { INVENTORY_TOTAL_FETCH_URL } from './AppConstants';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import PageLoading from './PresentationalComponents/PageLoading/PageLoading';
 import { DashboardRoutes } from './DashboardRoutes';
-import ZeroState from './PresentationalComponents/ZeroState/ZeroState';
-
-export const PermissionContext = createContext();
+import ZeroStateWrapper from './PresentationalComponents/ZeroState/AppZeroState';
+import PermissionsProvider from './PresentationalComponents/PermissionsProvider/PermissionsProvider';
 
 const App = (props) => {
     const chrome = useChrome();
     const dispatch = useDispatch();
-    const [permissions, setPermissions] = useState({
-        customPolicies: false,
-        compliance: false,
-        drift: false,
-        advisor: false,
-        remediations: false,
-        patch: false,
-        vulnerability: false,
-        subscriptions: false,
-        ros: false,
-        notifications: false
-    });
-    const [arePermissionsReady, setArePermissionReady] = useState(false);
-    const [hasSystems, setHasSystems] = useState();
-    const [systemsLoading, setSystemsLoading] = useState();
+    const [hasSystems, setHasSystems] = useState(false);
+    const [systemsLoading, setSystemsLoading] = useState(true);
 
-    async function initChrome() {
+    useEffect(() => {
         chrome?.globalFilterScope?.('insights');
         if (chrome?.globalFilterScope) {
             chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
@@ -44,77 +30,28 @@ const App = (props) => {
             });
         }
 
-        // TODO: Update this function to query multiple apps instead of empty request (limited by API)
-        chrome.getUserPermissions('', true).then(
-            dashboardPermissions => {
-                const permissionList = dashboardPermissions.length && dashboardPermissions.map(permissions => permissions.permission);
-                if (permissionList.length) {
-                    setPermissions({
-                        customPolicies: permissionList.includes('custom-policies:*:*'),
-                        compliance: permissionList.includes('compliance:*:*'),
-                        drift: permissionList.includes('drift:*:*'),
-                        advisor: permissionList.includes('insights:*:*') ||
-                            permissionList.includes('advisor:*:*'),
-                        remediations: permissionList.includes('remediations:*:*') ||
-                            permissionList.includes('remediations:remediation:*') ||
-                            permissionList.includes('remediations:remediation:read') ||
-                            permissionList.includes('remediations:*:read'),
-                        patch: permissionList.includes('patch:*:*'),
-                        vulnerability: permissionList.includes('vulnerability:*:*') ||
-                            permissionList.includes('vulnerability:vulnerability_results:read'),
-                        subscriptions: permissionList.includes('subscriptions:*:*') ||
-                            permissionList.includes('subscriptions:reports:read'),
-                        ros: permissionList.includes('ros:*:*') ||
-                            permissionList.includes('ros:*:read'),
-                        notifications: permissionList.includes('notifications:*:*') ||
-                            permissionList.includes('notifications:events:read')
-                    });
-                }
-
-                setArePermissionReady(true);
-            }
-        );
-        try {
-            const { total } = (await API.get(`${INVENTORY_TOTAL_FETCH_URL}`))?.data || { total: 0 };
-            setHasSystems(total > 0);
-            total === 0 && chrome.hideGlobalFilter();
-        } catch (e) {
+        API.get(`${INVENTORY_TOTAL_FETCH_URL}`).then(({ data }) => {
+            setHasSystems(data?.total > 0);
+            data?.total === 0 && chrome.hideGlobalFilter();
+            setSystemsLoading(false);
+        }).catch(() => {
             chrome.hideGlobalFilter();
-        }
-
-        setSystemsLoading(true);
-    }
-
-    useEffect(() => {
-        initChrome();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+            setSystemsLoading(false);
+        });
     }, []);
 
-    if (!arePermissionsReady || !systemsLoading) {
-        return <PageLoading />;
-    }
-
-    if (!hasSystems) {
-        return <ZeroState />;
-    }
-
-    return (
-        <PermissionContext.Provider
-            value={ {
-                customPolicies: permissions.customPolicies,
-                compliance: permissions.compliance,
-                drift: permissions.drift,
-                advisor: permissions.advisor,
-                remediations: permissions.remediations,
-                patch: permissions.patch,
-                vulnerability: permissions.vulnerability,
-                subscriptions: permissions.subscriptions,
-                ros: permissions.ros,
-                notifications: permissions.notifications
-            } }>
-            <DashboardRoutes childProps={ props } />
-        </PermissionContext.Provider>
-    );
+    return systemsLoading ? <PageLoading />
+        : (
+            <PermissionsProvider>
+                <ZeroStateWrapper
+                    app='Dashboard'
+                    appId='dashboard'
+                    customFetchResults={hasSystems}
+                >
+                    <DashboardRoutes childProps={ props } />
+                </ZeroStateWrapper>
+            </PermissionsProvider>
+        );
 };
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -30,7 +30,7 @@ const App = (props) => {
     });
     const [arePermissionsReady, setArePermissionReady] = useState(false);
     const [hasSystems, setHasSystems] = useState();
-    const [hasSystemsReady, setHasSystemsReady] = useState();
+    const [systemsLoading, setSystemsLoading] = useState();
 
     async function initChrome() {
         chrome?.globalFilterScope?.('insights');
@@ -82,7 +82,7 @@ const App = (props) => {
             chrome.hideGlobalFilter();
         }
 
-        setHasSystemsReady(true);
+        setSystemsLoading(true);
     }
 
     useEffect(() => {
@@ -90,11 +90,11 @@ const App = (props) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    if (!arePermissionsReady || !hasSystemsReady) {
+    if (!arePermissionsReady || !systemsLoading) {
         return <PageLoading />;
     }
 
-    if (hasSystemsReady && !hasSystems) {
+    if (!hasSystems) {
         return <ZeroState />;
     }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,7 +10,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('./Utilities/Api', () => ({
     ...jest.requireActual('./Utilities/Api'),
-    get: jest.fn(() => ({
+    get: jest.fn(() => Promise.resolve({
         data: { total: 0 }
     }))
 })

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import App from './App';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { init } from './Store';
+import Api from './Utilities/Api';
+import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
+import '@testing-library/jest-dom';
+
+jest.mock('./Utilities/Api', () => ({
+    ...jest.requireActual('./Utilities/Api'),
+    get: jest.fn(() => ({
+        data: { total: 0 }
+    }))
+})
+);
+
+jest.mock('./DashboardRoutes', () => ({
+    ...jest.requireActual('./DashboardRoutes'),
+    DashboardRoutes: jest.fn(() => (<div aria-label="Dashboard page"></div>))
+})
+);
+jest.mock('./PresentationalComponents/ZeroState/ZeroState', () => ({
+    __esModule: true,
+    default: jest.fn(() => (<div aria-label="Zero state banner"></div>))
+})
+);
+
+const renderDashboard = () => {
+    render(<BrowserRouter>
+        <IntlProvider>
+            <Provider store={init().getStore()}><App /></Provider>
+        </IntlProvider>
+    </BrowserRouter>);
+};
+
+jest.useFakeTimers();
+describe('App', () => {
+    it('Should render zero state when there is no registered systems', async () =>  {
+        renderDashboard();
+        await waitFor(() =>
+            expect(screen.getByLabelText('Zero state banner')).toBeVisible()
+        );
+    });
+    it('Should render Dashboard page when there is one or more registered systems', async () =>  {
+        Api.get.mockReturnValue(Promise.resolve({ data: { total: 10 } }));
+        renderDashboard();
+        await waitFor(() =>
+            expect(screen.getByLabelText('Dashboard page')).toBeVisible()
+        );
+    });
+
+    it('Should show loading page unless API request to check registered systems finish', async () =>  {
+        Api.get.mockImplementation(() => new Promise((resolve) => {
+            setTimeout(() => {
+                resolve({ data: { total: 10 } });
+            }, 1000);
+        }));
+        renderDashboard();
+        expect(screen.getByText('Loading')).toBeVisible();
+
+        jest.advanceTimersByTime(1000);
+        await waitFor(() =>
+            expect(screen.getByLabelText('Dashboard page')).toBeVisible()
+        );
+    });
+});

--- a/src/PresentationalComponents/Dashboard/Dashboard.js
+++ b/src/PresentationalComponents/Dashboard/Dashboard.js
@@ -1,13 +1,12 @@
 import './dashboard.scss';
 
-import { Grid, GridItem } from '@patternfly/react-core/dist/esm/layouts';
-import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core/dist/esm/components';
+import { Grid, GridItem } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 import React, { Suspense, lazy, useContext, useEffect } from 'react';
 
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import Masonry from 'react-masonry-css';
 import { PermissionContext } from '../../App';
-import ZeroState from '../ZeroState/ZeroState';
 import { connect } from 'react-redux';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
@@ -41,70 +40,67 @@ const Dashboard = (/*{ workloads }*/) => {
         chrome.updateDocumentTitle(`Dashboard | RHEL`);
     }, [chrome]);
 
-    return permission.hasSystems  ?
-        <React.Fragment>
-            <PageSection isWidthLimited variant={ PageSectionVariants.light } className="insd-c-dashboard-header">
-                <Title headingLevel="h1" size="2xl" className="pf-v5-u-screen-reader">
-                    {intl.formatMessage(messages.dashboardTitle)}
-                </Title>
+    return (<React.Fragment>
+        <PageSection isWidthLimited variant={ PageSectionVariants.light } className="insd-c-dashboard-header">
+            <Title headingLevel="h1" size="2xl" className="pf-v5-u-screen-reader">
+                {intl.formatMessage(messages.dashboardTitle)}
+            </Title>
+            <Suspense fallback={ <Loading /> }>
+                <SystemInventoryHeader/>
+            </Suspense>
+        </PageSection>
+        <PageSection isFilled={true} isWidthLimited>
+            <Grid hasGutter>
                 <Suspense fallback={ <Loading /> }>
-                    <SystemInventoryHeader/>
+                    {newRules?.length > 0 && permission.vulnerability && <GridItem>
+                        <NewRules />
+                    </GridItem> }
                 </Suspense>
-            </PageSection>
-            <PageSection isFilled={true} isWidthLimited>
-                <Grid hasGutter>
+                <Masonry
+                    breakpointCols={breakpointColumnsObj}
+                    className="ins-l-masonry"
+                    columnClassName="ins-l-masonry_column"
+                >
                     <Suspense fallback={ <Loading /> }>
-                        {newRules?.length > 0 && permission.vulnerability && <GridItem>
-                            <NewRules />
-                        </GridItem> }
-                    </Suspense>
-                    <Masonry
-                        breakpointCols={breakpointColumnsObj}
-                        className="ins-l-masonry"
-                        columnClassName="ins-l-masonry_column"
-                    >
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.vulnerability &&
+                        {permission.vulnerability &&
                                 <VulnerabilityCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.advisor &&
+                        }
+                    </Suspense>
+                    <Suspense fallback={ <Loading /> }>
+                        {permission.advisor &&
                                 <AdvisorCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.compliance &&
+                        }
+                    </Suspense>
+                    <Suspense fallback={ <Loading /> }>
+                        {permission.compliance &&
                                 <ComplianceCard />
-                            }
-                        </Suspense>
-                        <CentOsCard />
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.remediations &&
+                        }
+                    </Suspense>
+                    <CentOsCard />
+                    <Suspense fallback={ <Loading /> }>
+                        {permission.remediations &&
                                 <RemediationsCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.patch &&
+                        }
+                    </Suspense>
+                    <Suspense fallback={ <Loading /> }>
+                        {permission.patch &&
                                 <PatchManagerCard />
-                            }
-                        </Suspense>
-                        <Suspense fallback={ <Loading /> }>
-                            {permission.ros &&
+                        }
+                    </Suspense>
+                    <Suspense fallback={ <Loading /> }>
+                        {permission.ros &&
                                 <ResourceOptimizationCard/>
-                            }
-                        </Suspense>
-                        <Suspense>
-                            {permission.drift && permission.notifications
+                        }
+                    </Suspense>
+                    <Suspense>
+                        {permission.drift && permission.notifications
                             && <DriftCard/>}
-                        </Suspense>
-                    </Masonry>
-                </Grid>
-            </PageSection>
-            <Footer supportsSap={ true }/>
-        </React.Fragment>
-        :
-        <ZeroState/>;
+                    </Suspense>
+                </Masonry>
+            </Grid>
+        </PageSection>
+        <Footer supportsSap={ true }/>
+    </React.Fragment>);
 
 };
 

--- a/src/PresentationalComponents/Dashboard/Dashboard.js
+++ b/src/PresentationalComponents/Dashboard/Dashboard.js
@@ -6,7 +6,7 @@ import React, { Suspense, lazy, useContext, useEffect } from 'react';
 
 import Loading from '../../PresentationalComponents/Loading/Loading';
 import Masonry from 'react-masonry-css';
-import { PermissionContext } from '../../App';
+import { PermissionContext } from '../PermissionsProvider/PermissionsProvider';
 import { connect } from 'react-redux';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';

--- a/src/PresentationalComponents/PageLoading/PageLoading.js
+++ b/src/PresentationalComponents/PageLoading/PageLoading.js
@@ -1,8 +1,12 @@
 import './PageLoading.scss';
 
 import React from 'react';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { EmptyState, EmptyStateHeader, EmptyStateIcon } from '@patternfly/react-core';
+import {
+    EmptyState,
+    EmptyStateHeader,
+    EmptyStateIcon,
+    Spinner
+} from '@patternfly/react-core';
 
 const PageLoading = () => <EmptyState>
     <EmptyStateHeader titleText="Loading" headingLevel='h4' icon={<EmptyStateIcon icon={Spinner} />}/>

--- a/src/PresentationalComponents/PermissionsProvider/PermissionsProvider.js
+++ b/src/PresentationalComponents/PermissionsProvider/PermissionsProvider.js
@@ -1,0 +1,78 @@
+import React, { useState, createContext, useEffect } from 'react';
+import propTypes from 'prop-types';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import PageLoading from '../PageLoading/PageLoading';
+
+export const PermissionContext = createContext();
+
+const PermissionsProvider = ({ children }) => {
+    const chrome = useChrome();
+    const [permissions, setPermissions] = useState({
+        customPolicies: false,
+        compliance: false,
+        drift: false,
+        advisor: false,
+        remediations: false,
+        patch: false,
+        vulnerability: false,
+        subscriptions: false,
+        ros: false,
+        notifications: false
+    });
+    const [arePermissionsReady, setArePermissionReady] = useState(false);
+
+    useEffect(() => {
+        chrome.getUserPermissions('', true).then(
+            dashboardPermissions => {
+                const permissionList = dashboardPermissions.length && dashboardPermissions.map(permissions => permissions.permission);
+                if (permissionList.length) {
+                    setPermissions({
+                        customPolicies: permissionList.includes('custom-policies:*:*'),
+                        compliance: permissionList.includes('compliance:*:*'),
+                        drift: permissionList.includes('drift:*:*'),
+                        advisor: permissionList.includes('insights:*:*') ||
+                            permissionList.includes('advisor:*:*'),
+                        remediations: permissionList.includes('remediations:*:*') ||
+                            permissionList.includes('remediations:remediation:*') ||
+                            permissionList.includes('remediations:remediation:read') ||
+                            permissionList.includes('remediations:*:read'),
+                        patch: permissionList.includes('patch:*:*'),
+                        vulnerability: permissionList.includes('vulnerability:*:*') ||
+                            permissionList.includes('vulnerability:vulnerability_results:read'),
+                        subscriptions: permissionList.includes('subscriptions:*:*') ||
+                            permissionList.includes('subscriptions:reports:read'),
+                        ros: permissionList.includes('ros:*:*') ||
+                            permissionList.includes('ros:*:read'),
+                        notifications: permissionList.includes('notifications:*:*') ||
+                            permissionList.includes('notifications:events:read')
+                    });
+                }
+
+                setArePermissionReady(true);
+            }
+        );
+    }, []);
+
+    return arePermissionsReady ? (
+        <PermissionContext.Provider
+            value={ {
+                customPolicies: permissions.customPolicies,
+                compliance: permissions.compliance,
+                drift: permissions.drift,
+                advisor: permissions.advisor,
+                remediations: permissions.remediations,
+                patch: permissions.patch,
+                vulnerability: permissions.vulnerability,
+                subscriptions: permissions.subscriptions,
+                ros: permissions.ros,
+                notifications: permissions.notifications
+            } }>
+            {children}
+        </PermissionContext.Provider>
+    ) : <PageLoading />;
+};
+
+PermissionsProvider.propTypes = {
+    children: propTypes.element
+};
+export default PermissionsProvider;

--- a/src/PresentationalComponents/ZeroState/AppSection.js
+++ b/src/PresentationalComponents/ZeroState/AppSection.js
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardTitle, PageSection, Title } from '@patternfly/react-core/dist/esm/components';
+import { Card, CardBody, CardTitle, PageSection, Title } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import { Grid } from '@patternfly/react-core';
 import React from 'react';

--- a/src/PresentationalComponents/ZeroState/AppSectionItems.js
+++ b/src/PresentationalComponents/ZeroState/AppSectionItems.js
@@ -1,4 +1,4 @@
-import { Text, TextContent, TextVariants, Title } from '@patternfly/react-core/dist/esm/components';
+import { Text, TextContent, TextVariants, Title } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import { GridItem } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';

--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { Fragment, useEffect, useRef, useState } from 'react';
 import AppSection from './AppSection';
 import ZeroStateBanner from './ZeroStateBanner';
 import ZeroStateFooter from './ZeroStateFooter';
 import propTypes from 'prop-types';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import ZeroState from './ZeroState';
 
 //current stand in as we migrate away from the old version
 const AppZeroState = ({ children, ...props }) => {
@@ -52,21 +53,23 @@ const NewAppZeroState = ({
     }, [axios, customFetchResults, hasSystems]);
 
     return (
-        //If hasSystems is true, render routes
         hasSystems ? children :
             <IntlProvider>
-                <React.Fragment>
-                    <ZeroStateBanner
-                        appName={app}
-                        customInstructions={customInstructions}
-                        customButton={customButton}
-                        customText={customText}
-                        customTitle={customTitle}
-                        appId={appId}
-                    />
-                    <AppSection appName={app}/>
-                    <ZeroStateFooter appName={app} />
-                </React.Fragment>
+                {app.toLowerCase() === 'dashboard'
+                    ? <ZeroState />
+                    :  <Fragment>
+                        <ZeroStateBanner
+                            appName={app}
+                            customInstructions={customInstructions}
+                            customButton={customButton}
+                            customText={customText}
+                            customTitle={customTitle}
+                            appId={appId}
+                        />
+                        <AppSection appName={app}/>
+                        <ZeroStateFooter appName={app} />
+                    </Fragment>
+                }
             </IntlProvider>
     );
 };

--- a/src/PresentationalComponents/ZeroState/ZeroState.js
+++ b/src/PresentationalComponents/ZeroState/ZeroState.js
@@ -15,75 +15,18 @@ import {
     Flex,
     FlexItem
 } from '@patternfly/react-core';
-import React, { useEffect, useState } from 'react';
-import {
-    SortByDirection,
-    sortable,
-    TableBody,
-    TableHeader,
-    Table
-} from '@patternfly/react-table';
+import React, { useEffect } from 'react';
 
-import API from '../../Utilities/Api';
 import IconList from '../IconList/IconList';
 import IconListItem from '../IconList/IconListItem';
 import ImgInsSmartMgmt from '../../images/img__ins-and-sm.png';
 import MarketingBanner from '../MarketingBanner/MarketingBanner';
-import { UI_BASE, VULNERABILITIES_CVES_URL } from '../../AppConstants';
+import { UI_BASE } from '../../AppConstants';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { ArrowRightIcon } from '@patternfly/react-icons';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink/InsightsLink';
-
-// eslint-disable-next-line no-unused-vars
-const SortableTable = () => {
-    const columns = [
-        { title: 'CVE ID', transforms: [sortable] },
-        { title: 'Publish Date', transforms: [sortable] },
-        { title: 'Impact', transforms: [sortable] },
-        { title: 'CVSS Base Score', transforms: [sortable] }
-    ];
-    const [rows, setRows] = useState([]);
-    const [sortBy, setSort] = useState({});
-    const dateFormatter = (date) => {
-        const newDate = (new Date(date)).toString().split(' ');
-        return `${newDate[2]} ${newDate[1]} ${newDate[3]}`;
-    };
-
-    const rowBuilder = data => data.map(row => [{
-        title: <a href={ ` https://access.redhat.com/security/cve/${row.id}` }
-            target='_blank' rel='noreferrer'>{row.id}</a>
-    },
-    { title: <span>{dateFormatter(row.attributes.public_date)}</span> },
-    { title: <span>{row.attributes.impact}</span> },
-    { title: <span>{row.attributes.cvss3_score}</span> }]);
-
-    useEffect(() => {
-        const fetchCves = async () => {
-            try {
-                const cves = (await API.get(VULNERABILITIES_CVES_URL, {}, { sort: '-public_date', limit: 4 })).data;
-                setRows(rowBuilder(cves.data));
-            } catch (error) {
-                throw `${error}`;
-            }
-        };
-
-        fetchCves();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    const onSort = (_event, index, direction) => {
-        const sortedRows = rows.sort((a, b) => (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0));
-        setSort({ index, direction });
-        setRows(direction === SortByDirection.asc ? sortedRows : sortedRows.reverse());
-    };
-
-    return <Table aria-label='Sortable Table' sortBy={ sortBy } onSort={ onSort } cells={ columns } rows={ rows }>
-        <TableHeader />
-        <TableBody />
-    </Table>;
-};
 
 const ZeroState = () => {
     const intl = useIntl();

--- a/src/PresentationalComponents/ZeroState/ZeroStateBanner.js
+++ b/src/PresentationalComponents/ZeroState/ZeroStateBanner.js
@@ -2,10 +2,12 @@ import '../ZeroState/_zero-state.scss';
 
 import {
     Button,
-    Title
-} from '@patternfly/react-core/dist/esm/components/index';
-import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex/index';
-import { Grid, GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/index';
+    Title,
+    Grid,
+    GridItem,
+    Flex,
+    FlexItem
+} from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
 
 import IconList from '../IconList/IconList';

--- a/src/PresentationalComponents/ZeroState/ZeroStateFooter.js
+++ b/src/PresentationalComponents/ZeroState/ZeroStateFooter.js
@@ -3,12 +3,10 @@ import '../ZeroState/_zero-state.scss';
 
 import {
     Flex,
-    FlexItem
-} from '@patternfly/react-core/dist/esm/layouts/Flex/index';
-import {
+    FlexItem,
     Grid,
     GridItem
-} from '@patternfly/react-core/dist/esm/layouts/Grid/index';
+} from '@patternfly/react-core';
 import React from 'react';
 import zeroStateConstants from './zeroStateConstants';
 import propTypes from 'prop-types';

--- a/src/SmartComponents/Footer/Footer.js
+++ b/src/SmartComponents/Footer/Footer.js
@@ -4,7 +4,7 @@ import React, { useContext } from 'react';
 import { AppBlock } from '../../PresentationalComponents/Template/AppBlockTemplate';
 import ComplianceIcon from '../../images/Icon-Red_Hat-Software_and_technologies-App_Secured-A-Red-RGB.svg';
 import { Flex } from '@patternfly/react-core/dist/esm/layouts';
-import { PermissionContext } from '../../App';
+import { PermissionContext } from '../../PresentationalComponents/PermissionsProvider/PermissionsProvider';
 import RemediationsIcon from '../../images/Icon-Red_Hat-Software_and_Technologies-Automation-A-Red-RGB.svg';
 import { UI_BASE } from '../../AppConstants';
 import messages from '../../Messages';


### PR DESCRIPTION
This makes sure the Zero state banner is not shown during API requests. It also removes redux deprecated function `batch` as now React 18 defaults to batch state updates.

To test:
1. run the application
2. navigate to Dashboard page, observe that no zero state is shown even for milli-seconds if you have systems registered
3. navigate to some other app, and come back no zero state should be displayed
4. open some account without systems registered, observe that now zero state is shown