### PR TITLE
fix(CentOS card): Change the link for the CentOS card

### DIFF
--- a/src/PresentationalComponents/DownloadReport/DownloadReport.scss
+++ b/src/PresentationalComponents/DownloadReport/DownloadReport.scss
@@ -3,6 +3,6 @@
     padding-right: 0;
 }
 
-.pf-v5-c-button__icon {
+.insd-c-button-report-download.pf-v5-c-button__icon {
     color: var(--pf-v5-global--Color--100);
 }

--- a/src/PresentationalComponents/IconInline/IconInline.scss
+++ b/src/PresentationalComponents/IconInline/IconInline.scss
@@ -2,22 +2,23 @@
     font-size: var(--pf-v5-global--FontSize--sm);
 }
 
-.pf-v5-c-button__icon {
-    color: var(--pf-v5-global--Color--100);
-}
 
 .insd-c-dashboard__info-inline {
     display: flex;
     flex-direction: row;
     align-items: center;
-
+    
     p {
         font-size: var(--pf-v5-global--FontSize--sm);
         margin-left: var(--pf-v5-global--spacer--sm);
         color: var(--pf-v5-global--primary-color--100);
     }
-
+    
     &.insd-m-padding-top  {
         padding-top: var(--pf-v5-global--spacer--xs);
+    }
+    
+    .pf-v5-c-button__icon {
+        color: var(--pf-v5-global--Color--100);
     }
 }

--- a/src/SmartComponents/CentOs/CentOsCard.js
+++ b/src/SmartComponents/CentOs/CentOsCard.js
@@ -15,6 +15,7 @@ import { INVENTORY_CENTOS_FETCH_URL } from '../../AppConstants';
 import { ExpandableCardTemplate } from '../../PresentationalComponents/Template/ExpandableCardTemplate';
 import { TemplateCardBody } from '../../PresentationalComponents/Template/TemplateCard';
 import { EOLCountdownAlert } from './EOLCountdownAlert';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const CentOsCard = () => {
     const axios = useAxiosWithPlatformInterceptors();
@@ -119,11 +120,14 @@ const CentOsCard = () => {
                                 <FlexItem>
                                     <Button
                                         variant="secondary"
-                                        onClick={() =>
-                                            navigate('/available/convert-to-rhel-analysis')
-                                        }
+                                        component='a'
+                                        icon={<ExternalLinkAltIcon />}
+                                        iconPosition="end"
+                                        target='_blank'
+                                        // eslint-disable-next-line max-len
+                                        href="https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility_in_red_hat_insights/preparation-for-a-rhel-conversion-using-insights_converting-from-a-linux-distribution-to-rhel-in-insights"
                                     >
-                                        Start converting CentOS systems
+                                        Prepare CentOS systems to convert via Insights
                                     </Button>
                                 </FlexItem>
                             </>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-10693.

This changes the link and text of the button for the state when account doesn't have any CentOS systems registered.

![Screenshot 2024-07-15 at 16 42 03](https://github.com/user-attachments/assets/5b4cc80e-edb6-4b0a-9e2f-f592849d6239)
