### PR TITLE
Fix Drift card dropdown being bold

### DIFF
--- a/src/SmartComponents/Drift/DriftDropDown.js
+++ b/src/SmartComponents/Drift/DriftDropDown.js
@@ -29,7 +29,7 @@ const DriftDropDown = ({ fetchDriftData, selectedFilter }) => {
 
     return <Dropdown
         toggle={
-            <DropdownToggle onToggle={(_event, val) => setIsOpen(val)} toggleIndicator={CaretDownIcon}>
+            <DropdownToggle onToggle={(_event, val) => setIsOpen(val)} toggleIndicator={CaretDownIcon} style={{ fontWeight: 300 }}>
                 {selectedFilter.description}
             </DropdownToggle>
         }
@@ -38,7 +38,9 @@ const DriftDropDown = ({ fetchDriftData, selectedFilter }) => {
             <DropdownItem
                 key={key}
                 ref={(el) => dropdownItems.current[key].el = el}
-                onClick={() => onItemClick(item, dropdownItems.current[key].el)}>
+                onClick={() => onItemClick(item, dropdownItems.current[key].el)}
+                style={{ fontWeight: 300 }}
+            >
                 {item.description}
             </DropdownItem>
         ))}


### PR DESCRIPTION
The dropdown is inside the header component thus it inherited the increased font weight, but it should not have. 

## Before (see top right corner)
![Screenshot from 2024-08-09 18-15-57](https://github.com/user-attachments/assets/a41394c8-1c84-442a-98fb-603035292d37)

## After (see top right corner)
![Screenshot from 2024-08-09 18-16-02](https://github.com/user-attachments/assets/18ee254d-24a7-4bc2-8be6-c8138a00e364)
