### PR TITLE
Fix ROS cards number links being inconsistent

### DIFF
--- a/src/SmartComponents/ResourceOptimization/ResourceOptimizationCard.js
+++ b/src/SmartComponents/ResourceOptimization/ResourceOptimizationCard.js
@@ -64,31 +64,33 @@ const ResourceOptimizationCard = ({
                                                     </Flex>
                                             }
                                             <InsightsLink app='ros' to={suggestionsUrl}>
-                                            <Flex
-                                                direction={{ default: 'column' }}
-                                                spaceItems={{ default: 'spaceItemsNone' }}
-                                                alignItems={{ default: 'alignItemsCenter' }}>
+                                                <Flex
+                                                    direction={{ default: 'column' }}
+                                                    spaceItems={{ default: 'spaceItemsNone' }}
+                                                    alignItems={{ default: 'alignItemsCenter' }}
+                                                >
                                                     <span className='pf-v5-u-font-size-2xl pf-v5-u-color-100 pf-v5-u-font-weight-normal'>
-                                                    {rosIsConfigured.systems_stats.with_suggestions}
-                                                </span>
+                                                        {rosIsConfigured.systems_stats.with_suggestions}
+                                                    </span>
                                                     <span className='pf-v5-u-font-size-sm'>
                                                         {intl.formatMessage(messages.systemsWithSuggestions)}
                                                     </span>
                                                 </Flex>
-                                                </InsightsLink>
+                                            </InsightsLink>
                                             <InsightsLink app='ros' to={allSystemsUrl}>
-                                            <Flex
-                                                direction={{ default: 'column' }}
-                                                spaceItems={{ default: 'spaceItemsNone' }}
-                                                alignItems={{ default: 'alignItemsCenter' }}>
+                                                <Flex
+                                                    direction={{ default: 'column' }}
+                                                    spaceItems={{ default: 'spaceItemsNone' }}
+                                                    alignItems={{ default: 'alignItemsCenter' }}
+                                                >
                                                     <span className='pf-v5-u-font-size-2xl pf-v5-u-color-100 pf-v5-u-font-weight-normal'>
-                                                    {rosIsConfigured.count}
-                                                </span>
+                                                        {rosIsConfigured.count}
+                                                    </span>
                                                     <span className='pf-v5-u-font-size-sm'>
                                                         {intl.formatMessage(messages.totalSystems)}
                                                     </span>
                                                 </Flex>
-                                                </InsightsLink>
+                                            </InsightsLink>
                                         </Flex>
                                     </Flex>
 

--- a/src/SmartComponents/ResourceOptimization/ResourceOptimizationCard.js
+++ b/src/SmartComponents/ResourceOptimization/ResourceOptimizationCard.js
@@ -63,32 +63,32 @@ const ResourceOptimizationCard = ({
                                                         </InsightsLink>
                                                     </Flex>
                                             }
+                                            <InsightsLink app='ros' to={suggestionsUrl}>
                                             <Flex
                                                 direction={{ default: 'column' }}
                                                 spaceItems={{ default: 'spaceItemsNone' }}
                                                 alignItems={{ default: 'alignItemsCenter' }}>
-                                                <span className='pf-v5-u-font-size-2xl pf-v5-u-color-100 pf-v5-u-font-weight-bold'>
+                                                    <span className='pf-v5-u-font-size-2xl pf-v5-u-color-100 pf-v5-u-font-weight-normal'>
                                                     {rosIsConfigured.systems_stats.with_suggestions}
                                                 </span>
-                                                <InsightsLink app='ros' to={suggestionsUrl}>
                                                     <span className='pf-v5-u-font-size-sm'>
                                                         {intl.formatMessage(messages.systemsWithSuggestions)}
                                                     </span>
+                                                </Flex>
                                                 </InsightsLink>
-                                            </Flex>
+                                            <InsightsLink app='ros' to={allSystemsUrl}>
                                             <Flex
                                                 direction={{ default: 'column' }}
                                                 spaceItems={{ default: 'spaceItemsNone' }}
                                                 alignItems={{ default: 'alignItemsCenter' }}>
-                                                <span className='pf-v5-u-font-size-2xl pf-v5-u-color-100 pf-v5-u-font-weight-bold'>
+                                                    <span className='pf-v5-u-font-size-2xl pf-v5-u-color-100 pf-v5-u-font-weight-normal'>
                                                     {rosIsConfigured.count}
                                                 </span>
-                                                <InsightsLink app='ros' to={allSystemsUrl}>
                                                     <span className='pf-v5-u-font-size-sm'>
                                                         {intl.formatMessage(messages.totalSystems)}
                                                     </span>
+                                                </Flex>
                                                 </InsightsLink>
-                                            </Flex>
                                         </Flex>
                                     </Flex>
 


### PR DESCRIPTION
Previously, you could only click the text label under numbers in Resource optimization card to navigate to the ROS app. Now you can also click the numbers which is consistent with Advisor card. 

The change is just moving `InsightsLink` outside of the `Flex`.