### PR TITLE
refactor(ZeroState): Refactor ZeroState to accept wrapper and compone…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,8 @@ import { INVENTORY_TOTAL_FETCH_URL } from './AppConstants';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import PageLoading from './PresentationalComponents/PageLoading/PageLoading';
 import { DashboardRoutes } from './DashboardRoutes';
-import ZeroStateWrapper from './PresentationalComponents/ZeroState/AppZeroState';
 import PermissionsProvider from './PresentationalComponents/PermissionsProvider/PermissionsProvider';
+import ZeroState from './PresentationalComponents/ZeroState/ZeroState';
 
 const App = (props) => {
     const chrome = useChrome();
@@ -44,13 +44,7 @@ const App = (props) => {
     return systemsLoading ? <PageLoading />
         : (
             <PermissionsProvider>
-                <ZeroStateWrapper
-                    app='Dashboard'
-                    appId='dashboard'
-                    customFetchResults={hasSystems}
-                >
-                    <DashboardRoutes childProps={ props } />
-                </ZeroStateWrapper>
+                {hasSystems ? <DashboardRoutes childProps={ props } /> : <ZeroState/>}
             </PermissionsProvider>
         );
 };

--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -7,14 +7,9 @@ import { IntlProvider } from '@redhat-cloud-services/frontend-components-transla
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import ZeroState from './ZeroState';
 
-//current stand in as we migrate away from the old version
-const AppZeroState = ({ children, ...props }) => {
-    return (children ? <NewAppZeroState {...props}>{children}</NewAppZeroState> : <OldAppZeroState {...props} />);
-};
-
 const standardApiReq = '/api/inventory/v1/hosts?page=1&per_page=1';
 
-const NewAppZeroState = ({
+const AppZeroState = ({
     app,
     customInstructions,
     customButton,
@@ -51,72 +46,38 @@ const NewAppZeroState = ({
         return () => {
             mounted.current = false;
         };
-    }, [axios, customFetchResults, hasSystems]);
+    }, [axios, children, customFetchResults, hasSystems]);
 
-    return (
-        hasSystems ? children :
-            <IntlProvider>
-                {app.toLowerCase() === 'dashboard'
-                    ? <ZeroState />
-                    :  <Fragment>
-                        <ZeroStateBanner
-                            appName={app}
-                            customInstructions={customInstructions}
-                            customButton={customButton}
-                            customText={customText}
-                            customTitle={customTitle}
-                            appId={appId}
-                        />
-                        {customSection && customSection}
-                        <AppSection appName={app}/>
-                        <ZeroStateFooter appName={app} />
-                    </Fragment>
-                }
-            </IntlProvider>
-    );
-};
-
-//We will slowly migrate away from this
-const OldAppZeroState = ({
-    app,
-    customInstructions,
-    customButton,
-    customText,
-    customTitle,
-    appId
-}) => {
+    //If there are children, act as a wrapper, otherwise a component
     return (
         <IntlProvider>
-            <React.Fragment>
-                <ZeroStateBanner
-                    appName={app}
-                    customInstructions={customInstructions}
-                    customButton={customButton}
-                    customText={customText}
-                    customTitle={customTitle}
-                    appId={appId}
-                />
-                <AppSection appName={app}/>
-                <ZeroStateFooter appName={app} />
-            </React.Fragment>
+            {(children && hasSystems) ? (
+
+                children
+            ) : app.toLowerCase() === 'dashboard' ? (
+                <ZeroState />
+            ) : (
+                <>
+                    <ZeroStateBanner
+                        appName={app}
+                        customInstructions={customInstructions}
+                        customButton={customButton}
+                        customText={customText}
+                        customTitle={customTitle}
+                        appId={appId}
+                    />
+                    {customSection && customSection}
+                    <AppSection appName={app} />
+                    <ZeroStateFooter appName={app} />
+                </>
+            )}
         </IntlProvider>
     );
 };
 
 export default AppZeroState;
 
-OldAppZeroState.propTypes = {
-    app: propTypes.string,
-    customInstructions: propTypes.any,
-    customButton: propTypes.any,
-    customText: propTypes.string,
-    customTitle: propTypes.string,
-    appId: propTypes.string,
-    children: propTypes.any,
-    fetchSystem: propTypes.bool
-};
-
-NewAppZeroState.propTypes = {
+AppZeroState.propTypes = {
     app: propTypes.string,
     customInstructions: propTypes.any,
     customButton: propTypes.any,

--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -1,11 +1,10 @@
-import React, { Fragment, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import AppSection from './AppSection';
 import ZeroStateBanner from './ZeroStateBanner';
 import ZeroStateFooter from './ZeroStateFooter';
 import propTypes from 'prop-types';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
-import ZeroState from './ZeroState';
 
 const standardApiReq = '/api/inventory/v1/hosts?page=1&per_page=1';
 
@@ -54,8 +53,6 @@ const AppZeroState = ({
             {(children && hasSystems) ? (
 
                 children
-            ) : app.toLowerCase() === 'dashboard' ? (
-                <ZeroState />
             ) : (
                 <>
                     <ZeroStateBanner

--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -75,18 +75,14 @@ const AppZeroState = ({
 export default AppZeroState;
 
 AppZeroState.propTypes = {
-    app: propTypes.string,
+    children: propTypes.any,
     customInstructions: propTypes.any,
     customButton: propTypes.any,
     customText: propTypes.string,
     customTitle: propTypes.string,
     appId: propTypes.string,
-    children: propTypes.any,
     customFetchResults: propTypes.bool,
-    customSection: propTypes.node
-};
-AppZeroState.propTypes = {
-    children: propTypes.any,
+    customSection: propTypes.node,
     app: propTypes.oneOf([
         'Advisor',
         'Compliance',
@@ -100,5 +96,6 @@ AppZeroState.propTypes = {
         'Images',
         'Remediations',
         'Inventory',
-        'Tasks'])
+        'Tasks'
+    ])
 };

--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -5,6 +5,7 @@ import ZeroStateFooter from './ZeroStateFooter';
 import propTypes from 'prop-types';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import zeroStateAppList from './zeroStateConstants';
 
 const standardApiReq = '/api/inventory/v1/hosts?page=1&per_page=1';
 
@@ -74,6 +75,8 @@ const AppZeroState = ({
 
 export default AppZeroState;
 
+const appNames = Object.keys(zeroStateAppList).map(key => key.split('_')[0]);
+
 AppZeroState.propTypes = {
     children: propTypes.any,
     customInstructions: propTypes.any,
@@ -83,19 +86,5 @@ AppZeroState.propTypes = {
     appId: propTypes.string,
     customFetchResults: propTypes.bool,
     customSection: propTypes.node,
-    app: propTypes.oneOf([
-        'Advisor',
-        'Compliance',
-        'Drift',
-        'Insights',
-        'Content_management',
-        'Policies',
-        'Malware',
-        'Resource_optimization',
-        'Vulnerability',
-        'Images',
-        'Remediations',
-        'Inventory',
-        'Tasks'
-    ])
+    app: propTypes.oneOf(appNames)
 };

--- a/src/PresentationalComponents/ZeroState/AppZeroState.test.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.test.js
@@ -13,27 +13,40 @@ jest.mock(
     })
 );
 
-const intlProviderConfig = {
-    locale: 'en',
-    messages: {}
-};
+// const intlProviderConfig = {
+//     locale: 'en',
+//     messages: {}
+// };
 
-describe('NewAppZeroState component', () => {
+describe('AppZeroState component', () => {
 
-    it('renders zero state', async () => {
+    it('renders zero state if there ARE children but NO systems', async () => {
         render(
             <MemoryRouter initialEntries={['/some-path']}>
-                <IntlProvider {...intlProviderConfig}>
-                    <Routes>
-                        <Route path="/some-path" element={
-                            <AppZeroState app="Advisor" customFetchResults={false}>
-                                <div>
-                                    <div>testing here</div>
-                                </div>
-                            </AppZeroState>
-                        } />
-                    </Routes>
-                </IntlProvider>
+                <Routes>
+                    <Route path="/some-path" element={
+                        <AppZeroState app="Advisor" customFetchResults={false}>
+                            <div>
+                                <div>testing here</div>
+                            </div>
+                        </AppZeroState>
+                    } />
+                </Routes>
+            </MemoryRouter>
+        );
+
+        const zeroStateBanner = await screen.findByLabelText('ZeroStateBanner');
+        expect(zeroStateBanner).toBeInTheDocument();
+    });
+
+    it('renders zero state if there NO children and NO systems', async () => {
+        render(
+            <MemoryRouter initialEntries={['/some-path']}>
+                <Routes>
+                    <Route path="/some-path" element={
+                        <AppZeroState app="Advisor" customFetchResults={false}/>
+                    } />
+                </Routes>
             </MemoryRouter>
         );
         const zeroStateBanner = await screen.findByLabelText('ZeroStateBanner');
@@ -43,17 +56,15 @@ describe('NewAppZeroState component', () => {
     it('renders zero state with custom component', async () => {
         render(
             <MemoryRouter initialEntries={['/some-path']}>
-                <IntlProvider {...intlProviderConfig}>
-                    <Routes>
-                        <Route path="/some-path" element={
-                            <AppZeroState app="Advisor" customFetchResults={false} customSection={<div aria-label='custom-section'>hi</div>}>
-                                <div>
-                                    <div>testing here</div>
-                                </div>
-                            </AppZeroState>
-                        } />
-                    </Routes>
-                </IntlProvider>
+                <Routes>
+                    <Route path="/some-path" element={
+                        <AppZeroState app="Advisor" customFetchResults={false} customSection={<div aria-label='custom-section'>hi</div>}>
+                            <div>
+                                <div>testing here</div>
+                            </div>
+                        </AppZeroState>
+                    } />
+                </Routes>
             </MemoryRouter>
         );
 

--- a/src/PresentationalComponents/ZeroState/AppZeroState.test.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.test.js
@@ -4,6 +4,7 @@ import React from 'react';
 import AppZeroState from './AppZeroState';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import zeroStateAppList from './zeroStateConstants';
 
 jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors', () => ({
     __esModule: true,
@@ -13,6 +14,9 @@ jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors', (
     }))
 }));
 
+const appNames = Object.keys(zeroStateAppList).map(key => key.split('_')[0]);
+const randomApp = appNames[Math.floor(Math.random() * appNames.length)];
+
 describe('AppZeroState component', () => {
 
     it('renders zero state if there ARE children but NO systems', async () => {
@@ -20,7 +24,7 @@ describe('AppZeroState component', () => {
             <MemoryRouter initialEntries={['/some-path']}>
                 <Routes>
                     <Route path="/some-path" element={
-                        <AppZeroState app="Advisor" customFetchResults={false}>
+                        <AppZeroState app={randomApp} customFetchResults={false}>
                             <div>
                                 <div>testing here</div>
                             </div>
@@ -39,7 +43,7 @@ describe('AppZeroState component', () => {
             <MemoryRouter initialEntries={['/some-path']}>
                 <Routes>
                     <Route path="/some-path" element={
-                        <AppZeroState app="Advisor" customFetchResults={false}/>
+                        <AppZeroState app={randomApp} customFetchResults={false}/>
                     } />
                 </Routes>
             </MemoryRouter>
@@ -53,7 +57,7 @@ describe('AppZeroState component', () => {
             <MemoryRouter initialEntries={['/some-path']}>
                 <Routes>
                     <Route path="/some-path" element={
-                        <AppZeroState app="Advisor" customFetchResults={false} customSection={<div aria-label='custom-section'>hi</div>}>
+                        <AppZeroState app={randomApp} customFetchResults={false} customSection={<div aria-label='custom-section'>hi</div>}>
                             <div>
                                 <div>testing here</div>
                             </div>
@@ -76,7 +80,7 @@ describe('AppZeroState component', () => {
             <MemoryRouter initialEntries={['/some-path']}>
                 <Routes>
                     <Route path="/some-path" element={
-                        <AppZeroState app="Advisor" customFetchResults={true} customSection={<div aria-label='custom-section'>hi</div>}>
+                        <AppZeroState app={randomApp} customFetchResults={true} customSection={<div aria-label='custom-section'>hi</div>}>
                             <div>
                                 <div>testing here</div>
                             </div>
@@ -100,7 +104,7 @@ describe('AppZeroState component', () => {
             <MemoryRouter initialEntries={['/some-path']}>
                 <Routes>
                     <Route path="/some-path" element={
-                        <AppZeroState app="Advisor" />
+                        <AppZeroState app={randomApp} />
                     } />
                 </Routes>
             </MemoryRouter>
@@ -120,7 +124,7 @@ describe('AppZeroState component', () => {
             <MemoryRouter initialEntries={['/some-path']}>
                 <Routes>
                     <Route path="/some-path" element={
-                        <AppZeroState app="Advisor" >
+                        <AppZeroState app={randomApp} >
                             <div>
                                 <div>testing here</div>
                             </div>

--- a/src/PresentationalComponents/ZeroState/AppZeroState.test.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.test.js
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import AppZeroState from './AppZeroState';
-import { IntlProvider } from 'react-intl';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 jest.mock(
@@ -12,11 +11,6 @@ jest.mock(
         useAxiosWithPlatformInterceptors: jest.fn()
     })
 );
-
-// const intlProviderConfig = {
-//     locale: 'en',
-//     messages: {}
-// };
 
 describe('AppZeroState component', () => {
 
@@ -74,5 +68,23 @@ describe('AppZeroState component', () => {
         expect(zeroStateBanner).toBeInTheDocument();
         expect(customSection).toBeInTheDocument();
 
+    });
+
+    it('DOES NOT RENDER zero state if there ARE children and SOME systems', async () => {
+        render(
+            <MemoryRouter initialEntries={['/some-path']}>
+                <Routes>
+                    <Route path="/some-path" element={
+                        <AppZeroState app="Advisor" customFetchResults={true} customSection={<div aria-label='custom-section'>hi</div>}>
+                            <div>
+                                <div>testing here</div>
+                            </div>
+                        </AppZeroState>
+                    } />
+                </Routes>
+            </MemoryRouter>
+        );
+        const children = await screen.findByText('testing here');
+        expect(children).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
Currently Zero state essentially renders two different components based on if children are passed in or not. For a federated module this is a really ugly solution. 
This refactor reduces the code blocks so that its just '1 component' but can handle acting as both a wrapper or an individual component.

Note: theres no test for if there are NO CHILDREN and SOME systems because at that point its just a static component and the logic for that is handled outside of the component.