### PR TITLE
fix(sentryError): Fix network fetch error reported in sentry

### DIFF
--- a/src/PresentationalComponents/ZeroState/AppZeroState.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.js
@@ -32,7 +32,7 @@ const AppZeroState = ({
                     mounted.current && setHasSystems(customFetchResults);
                 } else {
                     axios.get(`${standardApiReq}`)
-                    .then(({ data }) => {
+                    .then((data) => {
                         mounted.current && setHasSystems(data.total > 0);
                     });
                 }

--- a/src/PresentationalComponents/ZeroState/AppZeroState.test.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.test.js
@@ -98,7 +98,7 @@ describe('AppZeroState component', () => {
 
     it('DOES render zero state when there are no systems in default request', async () => {
         const mockedGet = jest.spyOn(useAxiosWithPlatformInterceptors(), 'get')
-        .mockResolvedValue({ data: { total: 0 } });
+        .mockResolvedValue({ total: 0 });
 
         render(
             <MemoryRouter initialEntries={['/some-path']}>
@@ -118,7 +118,7 @@ describe('AppZeroState component', () => {
 
     it('DOES NOT render zero state when there ARE systems in default request', async () => {
         const mockedGet = jest.spyOn(useAxiosWithPlatformInterceptors(), 'get')
-        .mockResolvedValue({ data: { data: { total: 1 } } });
+        .mockResolvedValue({ total: 1 });
 
         render(
             <MemoryRouter initialEntries={['/some-path']}>


### PR DESCRIPTION
Theres is currently a small bug in production where 'total' is undefined in the base request from the api. This removes the brackets so that it simply grabs the object from the api and grabs the total. 

This is the slack thread: 
https://redhat-internal.slack.com/archives/C02T90PLJ5V/p1725048369737919 