### PR TITLE
[Typo] Fix small typo in dashboard footer

### DIFF
--- a/src/PresentationalComponents/ZeroState/ZeroStateFooter.js
+++ b/src/PresentationalComponents/ZeroState/ZeroStateFooter.js
@@ -91,7 +91,7 @@ const ZeroStateFooter = ({
                                 <a
                                     target='_blank'
                                     rel='noreferrer'
-                                    href='/edge'>Edge Managment</a>
+                                    href='/edge'>Edge Management</a>
                             </FlexItem>
                             <FlexItem>
                                 <a


### PR DESCRIPTION
- Fix for small typo found in the dashboard footer under "Other Bundles" should be Edge Management.

<img width="432" alt="Screenshot 2024-10-14 at 4 22 54 PM" src="https://github.com/user-attachments/assets/593f99b0-c523-4c79-9a4d-5c1fb9fe3a85">
