### PR TITLE
fix(RHINENG-17866): Fix buttons on loading

### DIFF
--- a/src/SmartComponents/Vulnerability/VulnerabilityCard.js
+++ b/src/SmartComponents/Vulnerability/VulnerabilityCard.js
@@ -220,16 +220,19 @@ const VulnerabilityCard = () => {
                                             </p>
                                         </TextContent>
                                     </div>
-                                    <InsightsLink
-                                        aria-label='Security rules link'
-                                        app='vulnerability'
-                                        to={`/cves?affecting=${affectingFilterValue}&rule_presence=true`}
-                                        rel='noreferrer'
-                                    >
-                                        <Button variant='secondary' size='sm'>
-                                            {intl.formatMessage(messages.vulnerabilityCardCTAText)}
-                                        </Button>
-                                    </InsightsLink>
+                                    {vulnerabilitiesFetchStatus === 'fulfilled'
+                                        ? <InsightsLink
+                                            aria-label='Security rules link'
+                                            app='vulnerability'
+                                            to={`/cves?affecting=${affectingFilterValue}&rule_presence=true`}
+                                            rel='noreferrer'
+                                        >
+                                            <Button variant='secondary' size='sm'>
+                                                {intl.formatMessage(messages.vulnerabilityCardCTAText)}
+                                            </Button>
+                                        </InsightsLink>
+                                        : <Skeleton fontSize="lg" width="50px" style={{ margin: 'auto' }}/>
+                                    }
                                 </div>
                                 <div className="insd-c-dashboard__card--Vulnerabilities--SplitMetrics__item">
                                     <div className="insd-c-dashboard__card--Vulnerabilities--SplitMetrics__content">
@@ -254,16 +257,18 @@ const VulnerabilityCard = () => {
                                             </p>
                                         </TextContent>
                                     </div>
-                                    <InsightsLink
-                                        aria-label='Known exploit link'
-                                        app='vulnerability'
-                                        to={`/cves?known_exploit=true&affecting=${affectingFilterValue}`}
-                                        rel='noreferrer'
-                                    >
-                                        <Button rel='noreferrer' variant='secondary' size='sm'>
-                                            {intl.formatMessage(messages.vulnerabilityCardKnownExploitsCTAText)}
-                                        </Button>
-                                    </InsightsLink>
+                                    {vulnerabilitiesFetchStatus === 'fulfilled'
+                                        ? <InsightsLink
+                                            aria-label='Known exploit link'
+                                            app='vulnerability'
+                                            to={`/cves?known_exploit=true&affecting=${affectingFilterValue}`}
+                                            rel='noreferrer'
+                                        >
+                                            <Button rel='noreferrer' variant='secondary' size='sm'>
+                                                {intl.formatMessage(messages.vulnerabilityCardKnownExploitsCTAText)}
+                                            </Button>
+                                        </InsightsLink>
+                                        : <Skeleton fontSize="lg" width="50px" style={{ margin: 'auto' }}/>}
                                 </div>
                             </div>
                         </Flex>


### PR DESCRIPTION
This PR fixes an issue where the "View CVEs" and "View known exploits" buttons don't have the filters they need because the data hasn't fully loaded. The `affectingFilterValue` is set to 'true' during the loading state, and if you click the buttons before the card is loaded, it will cause an error on the vulnerabilities tables.

This PR changes the `affectingFilterValue` to '' on loading, and more importantly, converts the buttons to a Skeleton on loading state so they cannot be clicked.

To test, go to `/insights/dashboard` and see that the "View CVEs" and "View known exploits" buttons are Skeletons on loading. Also, test that you cannot click them.