### PR TITLE
fix(Vulnerability card): Add loading skeletons around links to prevent crash

### DIFF
--- a/src/SmartComponents/Vulnerability/VulnerabilityCard.js
+++ b/src/SmartComponents/Vulnerability/VulnerabilityCard.js
@@ -25,7 +25,6 @@ import { global_disabled_color_100 } from '@patternfly/react-tokens';
 import messages from '../../Messages';
 import { useIntl } from 'react-intl';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink/InsightsLink';
-import { useFeatureFlag } from '../../Utilities/Hooks';
 import Api from '../../Utilities/Api';
 import { VULNERABILITIES_CVES_URL } from '../../AppConstants';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table/deprecated';
@@ -41,7 +40,7 @@ const VulnerabilityCard = () => {
     const SID = useSelector(({ DashboardStore }) => DashboardStore.SID);
     const strong = str => <strong>{str}</strong>;
     const [accountHasEdgeDevices, setAccountHasEdgeDevices] = useState(false);
-    const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
+    const [isEdgeDeviceCountLoading, setEdgeDeviceCountLoading] = useState(true);
 
     const iconTooltip = text => <Tooltip
         key={text}
@@ -85,16 +84,19 @@ const VulnerabilityCard = () => {
 
     useEffect(() => {
         const checkEdgeDevices = () => {
-            Api.get(VULNERABILITIES_CVES_URL, {}, { limit: 1 }).
-            then(
-                ({ data } = {}) => setAccountHasEdgeDevices(data?.meta?.system_count_per_type?.edge > 0 || false)
+            Api.get(VULNERABILITIES_CVES_URL, {}, { limit: 1 })
+            .then(
+                ({ data } = {}) => {
+                    setAccountHasEdgeDevices(data?.meta?.system_count_per_type?.edge > 0 || false);
+                    setEdgeDeviceCountLoading(false);
+                }
             );
         };
 
         checkEdgeDevices();
     }, []);
 
-    const affectingFilterValue = accountHasEdgeDevices && isEdgeParityEnabled ? 'rpmdnf,edge' : 'true';
+    const affectingFilterValue = accountHasEdgeDevices ? 'rpmdnf,edge' : 'true';
 
     const [chartData, rows] = useMemo(() => {
         let { cves_by_severity: bySeverity } = vulnerabilities;
@@ -127,37 +129,50 @@ const VulnerabilityCard = () => {
         const legendLink = (from, to) => `/cves?cvss_from=${from}&cvss_to=${to}&advisory_available=true&affecting=${affectingFilterValue}`;
 
         const rows = chartData.map(({ data, from, to, fill }) => [{
-            title: <TableText wrapModifier='nowrap' className='insd-c-legend__dot'
-                style={{ '--insd-c-legend__dot--BackgroundColor': `${fill}` }}>
-                <InsightsLink to={legendLink(from, to)} app='vulnerability'>{`${from}.0 - ${to}`}</InsightsLink>
-            </TableText>
+            title:
+                isEdgeDeviceCountLoading
+                    ? <Skeleton width="50px" />
+                    : (
+                        <TableText wrapModifier='nowrap' className='insd-c-legend__dot'
+                            style={{ '--insd-c-legend__dot--BackgroundColor': `${fill}` }}>
+                            <InsightsLink to={legendLink(from, to)} app='vulnerability'>{`${from}.0 - ${to}`}</InsightsLink>
+                        </TableText>
+                    )
         }, {
             title:
-                <InsightsLink
-                    app='vulnerability'
-                    to={legendLink(from, to)}
-                    className='pf-v5-u-text-align-center'
-                >
-                    {vulnerabilitiesFetchStatus === 'fulfilled'
-                        ? data.count
-                        : <Skeleton width="50px" style={{ margin: 'auto' }} />
-                    }
-                </InsightsLink>,
+                isEdgeDeviceCountLoading
+                    ? <Skeleton width="50px" style={{ margin: 'auto' }} />
+                    : (
+                        <InsightsLink
+                            app='vulnerability'
+                            to={legendLink(from, to)}
+                            className='pf-v5-u-text-align-center'
+                        >
+                            {vulnerabilitiesFetchStatus === 'fulfilled'
+                                ? data.count
+                                : <Skeleton width="50px" style={{ margin: 'auto' }} />
+                            }
+                        </InsightsLink>
+                    ),
             props: { textCenter: true }
         }, {
             title:
-                <InsightsLink
-                    app='vulnerability'
-                    to={legendLink(from, to) + '&known_exploit=true'}
-                    className='pf-v5-u-text-align-center'
-                >
-                    {vulnerabilitiesFetchStatus === 'fulfilled'
-                        ? data.known_exploits === undefined
-                            ? 'N/A'
-                            : data.known_exploits
-                        : <Skeleton width="50px" style={{ margin: 'auto' }} />
-                    }
-                </InsightsLink>,
+                isEdgeDeviceCountLoading
+                    ? <Skeleton width="50px" style={{ margin: 'auto' }} />
+                    : (
+                        <InsightsLink
+                            app='vulnerability'
+                            to={legendLink(from, to) + '&known_exploit=true'}
+                            className='pf-v5-u-text-align-center'
+                        >
+                            {vulnerabilitiesFetchStatus === 'fulfilled'
+                                ? data.known_exploits === undefined
+                                    ? 'N/A'
+                                    : data.known_exploits
+                                : <Skeleton width="50px" style={{ margin: 'auto' }} />
+                            }
+                        </InsightsLink>
+                    ),
             props: { textCenter: true }
         }]);
 
@@ -200,17 +215,22 @@ const VulnerabilityCard = () => {
                             <div className="insd-c-dashboard__card--Vulnerabilities--SplitMetrics">
                                 <div className="insd-c-dashboard__card--Vulnerabilities--SplitMetrics__item">
                                     <div className="insd-c-dashboard__card--Vulnerabilities--SplitMetrics__content">
-                                        <InsightsLink className='pf-v5-u-font-size-2xl pf-v5-u-color-100'
-                                            aria-label='Security rules link'
-                                            app='vulnerability'
-                                            to={`/cves?affecting=${affectingFilterValue}&rule_presence=true`}
-                                            rel='noreferrer'
-                                        >
-                                            {vulnerabilitiesFetchStatus === 'fulfilled'
-                                                ? vulnerabilities.rules_cves_total
-                                                : <Skeleton fontSize="lg" width="50px" style={{ margin: 'auto' }}/>
-                                            }
-                                        </InsightsLink>
+                                        {
+                                            isEdgeDeviceCountLoading
+                                                ? <Skeleton fontSize="2xl" width="50px" style={{ margin: 'auto' }} />
+                                                : (
+                                                    <InsightsLink className='pf-v5-u-font-size-2xl pf-v5-u-color-100'
+                                                        aria-label='Security rules link'
+                                                        app='vulnerability'
+                                                        to={`/cves?affecting=${affectingFilterValue}&rule_presence=true`}
+                                                        rel='noreferrer'
+                                                    >
+                                                        {vulnerabilitiesFetchStatus === 'fulfilled'
+                                                            ? vulnerabilities.rules_cves_total
+                                                            : <Skeleton fontSize="2xl" width="50px" style={{ margin: 'auto' }} />
+                                                        }
+                                                    </InsightsLink>
+                                                )}
                                         <TextContent>
                                             <p className='pf-v5-u-font-size-sm'>
                                                 {intl.formatMessage(messages.cvesImpactingOneOrMoreSystems, {
@@ -226,24 +246,29 @@ const VulnerabilityCard = () => {
                                         to={`/cves?affecting=${affectingFilterValue}&rule_presence=true`}
                                         rel='noreferrer'
                                     >
-                                        <Button variant='secondary' size='sm'>
+                                        <Button variant='secondary' size='sm' isDisabled={isEdgeDeviceCountLoading}>
                                             {intl.formatMessage(messages.vulnerabilityCardCTAText)}
                                         </Button>
                                     </InsightsLink>
                                 </div>
                                 <div className="insd-c-dashboard__card--Vulnerabilities--SplitMetrics__item">
                                     <div className="insd-c-dashboard__card--Vulnerabilities--SplitMetrics__content">
-                                        <InsightsLink
-                                            aria-label='Known exploit link'
-                                            className='pf-v5-u-font-size-2xl pf-v5-u-color-100'
-                                            app='vulnerability'
-                                            to={`/cves?known_exploit=true&affecting=${affectingFilterValue}`} rel='noreferrer'
-                                        >
-                                            {vulnerabilitiesFetchStatus === 'fulfilled'
-                                                ? vulnerabilities.exploited_cves_count
-                                                : <Skeleton fontSize="lg" width="50px" style={{ margin: 'auto' }}/>
-                                            }
-                                        </InsightsLink>
+                                        {
+                                            isEdgeDeviceCountLoading
+                                                ? <Skeleton fontSize="2xl" width="50px" style={{ margin: 'auto' }} />
+                                                : (
+                                                    <InsightsLink
+                                                        aria-label='Known exploit link'
+                                                        className='pf-v5-u-font-size-2xl pf-v5-u-color-100'
+                                                        app='vulnerability'
+                                                        to={`/cves?known_exploit=true&affecting=${affectingFilterValue}`} rel='noreferrer'
+                                                    >
+                                                        {vulnerabilitiesFetchStatus === 'fulfilled'
+                                                            ? vulnerabilities.exploited_cves_count
+                                                            : <Skeleton fontSize="2xl" width="50px" style={{ margin: 'auto' }} />
+                                                        }
+                                                    </InsightsLink>
+                                                )}
                                         <TextContent>
                                             <p className='pf-v5-u-font-size-sm'>
                                                 {intl.formatMessage(messages.knownExploitsOneOrMoreSystems, {
@@ -260,7 +285,7 @@ const VulnerabilityCard = () => {
                                         to={`/cves?known_exploit=true&affecting=${affectingFilterValue}`}
                                         rel='noreferrer'
                                     >
-                                        <Button rel='noreferrer' variant='secondary' size='sm'>
+                                        <Button rel='noreferrer' variant='secondary' size='sm' isDisabled={isEdgeDeviceCountLoading}>
                                             {intl.formatMessage(messages.vulnerabilityCardKnownExploitsCTAText)}
                                         </Button>
                                     </InsightsLink>
@@ -292,7 +317,7 @@ const VulnerabilityCard = () => {
                                         colorScale={vulnerabilitiesFetchStatus === 'fulfilled' && vulnerabilities.cves_total === 0 ?
                                             [global_disabled_color_100.value] : ['#a30000', '#ec7a08', '#f0ab00']}
                                     />
-                                    : <Spinner style={{ width: 100 }}/>
+                                    : <Spinner style={{ width: 100 }} />
                                 }
                             </div>
                             <div className="insd-c-dashboard__card-pie-chart-legend">


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHINENG-17866
The problem: Vulnerability card needs to fetch edge system count so that it correctly sets up the links to Vulnerability app. If a user clicks a link before the edge system count has been retrieved, they might click an incorrect link and get a page crash upon being navigated to Vulnerability.
The solution: Remove obsolete feature flag to speed up loading and add loading skeletons+disable buttons until the edge count is retrieved.

### Edge system count is being loaded
![Screenshot From 2025-06-10 17-10-53](https://github.com/user-attachments/assets/f3c337c7-4453-4bbb-8256-9940593403ad)

### Loaded state
![Screenshot From 2025-06-10 17-14-17](https://github.com/user-attachments/assets/24403114-b371-4e59-91e6-0e2ff3f38323)