### PR TITLE
feat(RHINENG-19699): Change Remediation plans' naming on ZeroState page

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "nightly": "npm run ci:verify",
     "postinstall": "ts-patch install",
     "server:ctr": "node src/server/generateServerKey.js",
-    "start": "fec dev",
+    "start": "fec static",
     "start:proxy": "PROXY=true fec dev",
     "test": "jest --passWithNoTests",
     "test:coverage": "curl -sSL 'https://raw.githubusercontent.com/RedHatInsights/insights-interact-tools/refs/heads/main/scripts/coverage.sh' | bash",

--- a/src/PresentationalComponents/ZeroState/ZeroStateFooter.js
+++ b/src/PresentationalComponents/ZeroState/ZeroStateFooter.js
@@ -15,6 +15,9 @@ const ZeroStateFooter = ({
     appName,
     documentation = zeroStateConstants[`${appName.toUpperCase()}_ZERO_STATE`].documentation
 }) => {
+    // Prefer an explicit documentationTitleText from constants when available
+    const configuredTitle = zeroStateConstants[`${appName.toUpperCase()}_ZERO_STATE`]?.documentationTitleText;
+    const documentationTitleText = configuredTitle || appName.replace('_', ' ') + ' documentation';
     return (
         <PageSection hasBodyWrapper className='footer' isWidthLimited>
             <Card>
@@ -22,7 +25,7 @@ const ZeroStateFooter = ({
                     <GridItem>
                         <Flex direction={{ default: 'column' }}>
                             <FlexItem>
-                                <Title headingLevel='h3' size='lg'>{appName.replace('_', ' ')} documentation</Title>
+                                <Title headingLevel='h3' size='lg'>{documentationTitleText}</Title>
                             </FlexItem>
                             {documentation.map(item => (
                                 <FlexItem key={item.title} >

--- a/src/PresentationalComponents/ZeroState/zeroStateConstants.js
+++ b/src/PresentationalComponents/ZeroState/zeroStateConstants.js
@@ -485,13 +485,13 @@ const IMAGES_ZERO_STATE = {
     ]
 };
 
-const REMEDIATIONS_ZERO_STATE = {
+const REMEDIATION_PLANS_ZERO_STATE = {
     header: {
         description:
       `Use remediation guidance provided by Red Hat Insights services to take manual actions or create playbooks for resolution at scale.`,
         bulletPoints: [
-            'Download playbooks or execute directly to remediate risk',
-            'Execute remediations playbooks directly via Red Hat Satellite or remote host configuration (rhc)'
+            'Download remediation plan playbooks or execute directly to remediate risk',
+            'Execute remediation plan playbooks directly via Red Hat Satellite or remote host configuration (rhc)'
         ],
         commands: [
             { plainText: ' 1. Register your host' },
@@ -531,6 +531,7 @@ const REMEDIATIONS_ZERO_STATE = {
             link: '/insights/patch'
         }
     ],
+    documentationTitleText: 'Documentation',
     documentation: [
         {
             title: 'Red Hat Insights Remediations Guide',
@@ -538,6 +539,8 @@ const REMEDIATIONS_ZERO_STATE = {
         }
     ]
 };
+// TODO: Remove after https://github.com/RedHatInsights/insights-remediations-frontend/pull/603 is merged
+const REMEDIATIONS_ZERO_STATE = REMEDIATION_PLANS_ZERO_STATE;
 
 const INVENTORY_ZERO_STATE = {
     header: {
@@ -649,6 +652,7 @@ export default {
     RESOURCE_OPTIMIZATION_ZERO_STATE,
     VULNERABILITY_ZERO_STATE,
     IMAGES_ZERO_STATE,
+    REMEDIATION_PLANS_ZERO_STATE,
     REMEDIATIONS_ZERO_STATE,
     INVENTORY_ZERO_STATE,
     TASKS_ZERO_STATE


### PR DESCRIPTION
Changes of Remediation app's naming on ZeroState page from Remediations to Remediation plans.

JIRA ticket: https://issues.redhat.com/browse/RHINENG-19699
PR on remediations side: https://github.com/RedHatInsights/insights-remediations-frontend/pull/603