### PR TITLE
feat(RHINENG-20820): Rebrand to Lightspeed

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -34,7 +34,7 @@
     "enhancementAdvisories": "{count, plural, one {enhancement} other {enhancements}}",
     "systemsAffected": "{count, plural, one {# system} other {# systems}} affected",
     "patchTitle": "Patch",
-    "systemInventoryDescription": "{count, plural, one {System} other {Systems}} registered with Insights",
+    "systemInventoryDescription": "{count, plural, one {System} other {Systems}} registered with {productName}",
     "systemInventoryStaleWarning": "{count, plural, one {# system} other {# systems}} to be removed",
     "systemInventoryStale": "{count, plural, one {# stale system} other {# stale systems}}",
     "systemInventoryPercentageData": "{count}% of total systems",

--- a/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
@@ -27,6 +27,7 @@ import { usePermissions } from '@redhat-cloud-services/frontend-components-utili
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink/InsightsLink';
 import { Link } from 'react-router-dom';
 import { useBatchInventoryFetch } from '../../Utilities/useBatchInventoryFetch';
+import { useFeatureFlag } from '../../Utilities/Hooks';
 
 /**
  * System inventory card for showing system inventory and status.
@@ -34,6 +35,7 @@ import { useBatchInventoryFetch } from '../../Utilities/useBatchInventoryFetch';
 const SystemInventoryHeader = ({
     selectedTags, workloads, SID
 }) => {
+    const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
 
     const { hasAccess } = usePermissions('inventory', [
         'inventory:*:*',
@@ -74,7 +76,9 @@ const SystemInventoryHeader = ({
                                         data={inventorySummary?.total.toLocaleString() || 0 }
                                         dataSize="lg"
                                         linkDescription={ intl.formatMessage(messages.systemInventoryDescription,
-                                            { count: inventorySummary?.total || 0 }
+                                            { count: inventorySummary?.total || 0,
+                                                productName: isLightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'
+                                            }
                                         ) }
                                         app='inventory'
                                         link='/?source=puptoo'


### PR DESCRIPTION
### How to test:

1. Navgate to Dashboard page
2. Check wording for registered systems
3. Depending of FF it should be Red Hat Lightspeed or Insights


<img width="758" height="523" alt="Screenshot 2025-09-17 at 10 39 52" src="https://github.com/user-attachments/assets/4daa667f-702f-45ee-95d5-13d0d386f327" />
