### PR TITLE
fix(Kessel): add Kessel checks for Inventory

### DIFF
--- a/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryHeader.js
@@ -1,184 +1,70 @@
-import './SystemInventoryHeader.scss';
-// layouts
-import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts';
 import React from 'react';
-import { workloadsPropType } from '../../Utilities/Common';
-
-// components
-import { Button, Skeleton } from '@patternfly/react-core/dist/esm/components';
-import FailState from '../../PresentationalComponents/FailState/FailState';
-// icons
-import { IconInline } from '../../PresentationalComponents/IconInline/IconInline';
-import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
-import { NumberDescription } from '../../PresentationalComponents/NumberDescription/NumberDescription';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import messages from '../../Messages';
-import { useIntl } from 'react-intl';
-
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook/RBACHook';
-import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink/InsightsLink';
-import { Link } from 'react-router-dom';
-import { useBatchInventoryFetch } from '../../Utilities/useBatchInventoryFetch';
+import { workloadsPropType } from '../../Utilities/Common';
 import { useFeatureFlag } from '../../Utilities/Hooks';
+import { useInventoryHostsReadKesselProbe } from '../../Utilities/hooks/useInventoryHostsReadKesselProbe';
+import SystemInventoryHeaderContent from './SystemInventoryHeaderContent';
 
-/**
- * System inventory card for showing system inventory and status.
- */
-const SystemInventoryHeader = ({ selectedTags, workloads }) => {
-  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+const INVENTORY_HOST_READ_PERMISSIONS = ['inventory:hosts:read'];
 
-  const { hasAccess } = usePermissions('inventory', [
-    'inventory:*:*',
-    'inventory:*:read',
-    'inventory:hosts:*',
-    'inventory:hosts:read',
-  ]);
-
-  const [
-    isLoading,
-    inventorySummary,
-    inventoryWarningSummary,
-    inventoryStaleSum,
-    error,
-  ] = useBatchInventoryFetch(workloads, selectedTags, hasAccess);
-
-  const intl = useIntl();
+const SystemInventoryHeaderWithRbac = ({ selectedTags, workloads }) => {
+  const { hasAccess, isLoading } = usePermissions(
+    'inventory',
+    INVENTORY_HOST_READ_PERMISSIONS,
+  );
 
   return (
-    <React.Fragment>
-      {hasAccess === false ? (
-        <NotAuthorized
-          showReturnButton={false}
-          serviceName="Inventory"
-          icon={() => ''}
-          variant="xs"
-          description={
-            <div>{intl.formatMessage(messages.systemInventoryNoAccess)}</div>
-          }
-        />
-      ) : (
-        <React.Fragment>
-          {!error ? (
-            <Flex
-              spaceItems={{ md: 'spaceItemsXl' }}
-              alignItems={{ md: 'alignItemsCenter' }}
-              direction={{ default: 'column', md: 'row' }}
-            >
-              <Flex spaceItems={{ default: 'spaceItemsXl' }}>
-                {isLoading ? (
-                  <Skeleton fontSize="4xl" width="200px" />
-                ) : (
-                  <NumberDescription
-                    data={inventorySummary?.total.toLocaleString() || 0}
-                    dataSize="lg"
-                    linkDescription={intl.formatMessage(
-                      messages.systemInventoryDescription,
-                      {
-                        count: inventorySummary?.total || 0,
-                        productName: isLightspeedEnabled
-                          ? 'the insights-client'
-                          : 'Insights',
-                      },
-                    )}
-                    app="inventory"
-                    link="/?source=puptoo"
-                  />
-                )}
-                {/* {inventoryFetchStatus === 'fulfilled' && inventoryTotalFetchStatus === 'fulfilled' &&
-                            <NumberDescription
-                                data={ inventoryTotalSummary.total - inventorySummary.total || 0 }
-                                dataSize="lg"
-                                linkDescription={ intl.formatMessage(messages.systemInventoryUnregisteredDescription,
-                                    { count: inventoryTotalSummary.total || 0 }
-                                ) }
-                                link='./insights/inventory'
-                            />
-                        } */}
-              </Flex>
-              <Flex
-                spaceItems={{ default: 'spaceItemsXl' }}
-                alignItems={{ md: 'alignItemsCenter' }}
-                flex={{ default: 'flex_1' }}
-                direction={{ default: 'column', md: 'row' }}
-              >
-                <Flex
-                  direction={{ default: 'column' }}
-                  spaceItems={{ default: 'spaceItemsNone' }}
-                >
-                  <FlexItem>
-                    {isLoading ? (
-                      <Skeleton
-                        width="200px"
-                        style={{ marginBottom: 4, marginTop: 4 }}
-                      />
-                    ) : (
-                      <InsightsLink
-                        app="inventory"
-                        to="/?status=stale&source=puptoo"
-                        className="pf-v6-c-button pf-m-link pf-m-inline"
-                      >
-                        <IconInline
-                          message={intl.formatMessage(
-                            messages.systemInventoryStale,
-                            { count: inventoryStaleSum?.total || 0 },
-                          )}
-                          state="warning"
-                          systemInventory
-                        />
-                      </InsightsLink>
-                    )}
-                  </FlexItem>
-                  <FlexItem>
-                    {isLoading ? (
-                      <Skeleton width="200px" />
-                    ) : (
-                      <InsightsLink
-                        app="inventory"
-                        to="/?status=stale_warning&source=puptoo"
-                        className="pf-v6-c-button pf-m-link pf-m-inline"
-                      >
-                        <IconInline
-                          message={intl.formatMessage(
-                            messages.systemInventoryStaleWarning,
-                            { count: inventoryWarningSummary?.total || 0 },
-                          )}
-                          state="critical"
-                          systemInventory
-                        />
-                      </InsightsLink>
-                    )}
-                  </FlexItem>
-                </Flex>
-                <FlexItem align={{ md: 'alignRight' }}>
-                  <Link to="/settings/integrations?category=Communications">
-                    <Button
-                      className="pf-v6-u-mr-sm pf-v6-u-font-size-md"
-                      variant="secondary"
-                      size="sm"
-                    >
-                      {intl.formatMessage(messages.configureIntegrations)}
-                    </Button>
-                  </Link>
-                  <InsightsLink app="registration" to="/">
-                    <Button variant="primary">
-                      {intl.formatMessage(messages.systemInventoryCTA)}
-                    </Button>
-                  </InsightsLink>
-                </FlexItem>
-              </Flex>
-            </Flex>
-          ) : (
-            <FailState appName="Inventory" isSmall />
-          )}
-        </React.Fragment>
-      )}
-    </React.Fragment>
+    <SystemInventoryHeaderContent
+      selectedTags={selectedTags}
+      workloads={workloads}
+      hasInventoryHostRead={hasAccess}
+      isInventoryHostReadLoading={isLoading}
+    />
+  );
+};
+
+const SystemInventoryHeaderWithKessel = ({ selectedTags, workloads }) => {
+  const { hasAccess, isLoading } = useInventoryHostsReadKesselProbe();
+
+  return (
+    <SystemInventoryHeaderContent
+      selectedTags={selectedTags}
+      workloads={workloads}
+      hasInventoryHostRead={hasAccess}
+      isInventoryHostReadLoading={isLoading}
+    />
+  );
+};
+
+const SystemInventoryHeader = ({ selectedTags, workloads }) => {
+  const isKesselEnabled = useFeatureFlag('insights-dashboard.kessel_enabled');
+
+  return isKesselEnabled ? (
+    <SystemInventoryHeaderWithKessel
+      selectedTags={selectedTags}
+      workloads={workloads}
+    />
+  ) : (
+    <SystemInventoryHeaderWithRbac
+      selectedTags={selectedTags}
+      workloads={workloads}
+    />
   );
 };
 
 SystemInventoryHeader.propTypes = {
-  intl: PropTypes.any,
+  selectedTags: PropTypes.arrayOf(PropTypes.string),
+  workloads: workloadsPropType,
+};
+
+SystemInventoryHeaderWithRbac.propTypes = {
+  selectedTags: PropTypes.arrayOf(PropTypes.string),
+  workloads: workloadsPropType,
+};
+
+SystemInventoryHeaderWithKessel.propTypes = {
   selectedTags: PropTypes.arrayOf(PropTypes.string),
   workloads: workloadsPropType,
 };

--- a/src/SmartComponents/SystemInventory/SystemInventoryHeaderContent.js
+++ b/src/SmartComponents/SystemInventory/SystemInventoryHeaderContent.js
@@ -1,0 +1,204 @@
+import './SystemInventoryHeader.scss';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/esm/layouts';
+import React from 'react';
+import { workloadsPropType } from '../../Utilities/Common';
+import { Button, Skeleton } from '@patternfly/react-core/dist/esm/components';
+import FailState from '../../PresentationalComponents/FailState/FailState';
+import { IconInline } from '../../PresentationalComponents/IconInline/IconInline';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
+import { NumberDescription } from '../../PresentationalComponents/NumberDescription/NumberDescription';
+import PropTypes from 'prop-types';
+import messages from '../../Messages';
+import { useIntl } from 'react-intl';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink/InsightsLink';
+import { Link } from 'react-router-dom';
+import { useBatchInventoryFetch } from '../../Utilities/useBatchInventoryFetch';
+import { useFeatureFlag } from '../../Utilities/Hooks';
+
+const accessLoadingSkeleton = (
+  <Flex
+    spaceItems={{ md: 'spaceItemsXl' }}
+    alignItems={{ md: 'alignItemsCenter' }}
+    direction={{ default: 'column', md: 'row' }}
+  >
+    <Flex spaceItems={{ default: 'spaceItemsXl' }}>
+      <Skeleton fontSize="4xl" width="200px" />
+    </Flex>
+    <Flex
+      spaceItems={{ default: 'spaceItemsXl' }}
+      alignItems={{ md: 'alignItemsCenter' }}
+      flex={{ default: 'flex_1' }}
+      direction={{ default: 'column', md: 'row' }}
+    >
+      <Flex
+        direction={{ default: 'column' }}
+        spaceItems={{ default: 'spaceItemsNone' }}
+      >
+        <FlexItem>
+          <Skeleton width="200px" style={{ marginBottom: 4, marginTop: 4 }} />
+        </FlexItem>
+        <FlexItem>
+          <Skeleton width="200px" />
+        </FlexItem>
+      </Flex>
+      <FlexItem align={{ md: 'alignRight' }}>
+        <Skeleton width="120px" height="32px" className="pf-v6-u-mr-sm" />
+        <Skeleton width="140px" height="32px" />
+      </FlexItem>
+    </Flex>
+  </Flex>
+);
+
+const SystemInventoryHeaderContent = ({
+  selectedTags,
+  workloads,
+  hasInventoryHostRead,
+  isInventoryHostReadLoading,
+}) => {
+  const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+  const mayFetch = !isInventoryHostReadLoading && hasInventoryHostRead === true;
+
+  const [
+    isLoading,
+    inventorySummary,
+    inventoryWarningSummary,
+    inventoryStaleSum,
+    error,
+  ] = useBatchInventoryFetch(workloads, selectedTags, mayFetch);
+
+  const intl = useIntl();
+
+  if (isInventoryHostReadLoading) {
+    return <React.Fragment>{accessLoadingSkeleton}</React.Fragment>;
+  }
+
+  if (hasInventoryHostRead === false) {
+    return (
+      <NotAuthorized
+        showReturnButton={false}
+        serviceName="Inventory"
+        icon={() => ''}
+        variant="xs"
+        description={
+          <div>{intl.formatMessage(messages.systemInventoryNoAccess)}</div>
+        }
+      />
+    );
+  }
+
+  return (
+    <React.Fragment>
+      {!error ? (
+        <Flex
+          spaceItems={{ md: 'spaceItemsXl' }}
+          alignItems={{ md: 'alignItemsCenter' }}
+          direction={{ default: 'column', md: 'row' }}
+        >
+          <Flex spaceItems={{ default: 'spaceItemsXl' }}>
+            {isLoading ? (
+              <Skeleton fontSize="4xl" width="200px" />
+            ) : (
+              <NumberDescription
+                data={inventorySummary?.total.toLocaleString() || 0}
+                dataSize="lg"
+                linkDescription={intl.formatMessage(
+                  messages.systemInventoryDescription,
+                  {
+                    count: inventorySummary?.total || 0,
+                    productName: isLightspeedEnabled
+                      ? 'the insights-client'
+                      : 'Insights',
+                  },
+                )}
+                app="inventory"
+                link="/?source=puptoo"
+              />
+            )}
+          </Flex>
+          <Flex
+            spaceItems={{ default: 'spaceItemsXl' }}
+            alignItems={{ md: 'alignItemsCenter' }}
+            flex={{ default: 'flex_1' }}
+            direction={{ default: 'column', md: 'row' }}
+          >
+            <Flex
+              direction={{ default: 'column' }}
+              spaceItems={{ default: 'spaceItemsNone' }}
+            >
+              <FlexItem>
+                {isLoading ? (
+                  <Skeleton
+                    width="200px"
+                    style={{ marginBottom: 4, marginTop: 4 }}
+                  />
+                ) : (
+                  <InsightsLink
+                    app="inventory"
+                    to="/?status=stale&source=puptoo"
+                    className="pf-v6-c-button pf-m-link pf-m-inline"
+                  >
+                    <IconInline
+                      message={intl.formatMessage(
+                        messages.systemInventoryStale,
+                        { count: inventoryStaleSum?.total || 0 },
+                      )}
+                      state="warning"
+                      systemInventory
+                    />
+                  </InsightsLink>
+                )}
+              </FlexItem>
+              <FlexItem>
+                {isLoading ? (
+                  <Skeleton width="200px" />
+                ) : (
+                  <InsightsLink
+                    app="inventory"
+                    to="/?status=stale_warning&source=puptoo"
+                    className="pf-v6-c-button pf-m-link pf-m-inline"
+                  >
+                    <IconInline
+                      message={intl.formatMessage(
+                        messages.systemInventoryStaleWarning,
+                        { count: inventoryWarningSummary?.total || 0 },
+                      )}
+                      state="critical"
+                      systemInventory
+                    />
+                  </InsightsLink>
+                )}
+              </FlexItem>
+            </Flex>
+            <FlexItem align={{ md: 'alignRight' }}>
+              <Link to="/settings/integrations?category=Communications">
+                <Button
+                  className="pf-v6-u-mr-sm pf-v6-u-font-size-md"
+                  variant="secondary"
+                  size="sm"
+                >
+                  {intl.formatMessage(messages.configureIntegrations)}
+                </Button>
+              </Link>
+              <InsightsLink app="registration" to="/">
+                <Button variant="primary">
+                  {intl.formatMessage(messages.systemInventoryCTA)}
+                </Button>
+              </InsightsLink>
+            </FlexItem>
+          </Flex>
+        </Flex>
+      ) : (
+        <FailState appName="Inventory" isSmall />
+      )}
+    </React.Fragment>
+  );
+};
+
+SystemInventoryHeaderContent.propTypes = {
+  selectedTags: PropTypes.arrayOf(PropTypes.string),
+  workloads: workloadsPropType,
+  hasInventoryHostRead: PropTypes.bool.isRequired,
+  isInventoryHostReadLoading: PropTypes.bool.isRequired,
+};
+
+export default SystemInventoryHeaderContent;

--- a/src/Utilities/hooks/useInventoryHostsReadKesselProbe.js
+++ b/src/Utilities/hooks/useInventoryHostsReadKesselProbe.js
@@ -1,0 +1,30 @@
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import { useEffect, useState } from 'react';
+import { INVENTORY_TOTAL_FETCH_URL } from '../../AppConstants';
+
+export const useInventoryHostsReadKesselProbe = () => {
+  const axios = useAxiosWithPlatformInterceptors();
+  const [state, setState] = useState({
+    isLoading: true,
+    hasAccess: false,
+  });
+
+  useEffect(() => {
+    const probe = async () => {
+      try {
+        await axios.get(INVENTORY_TOTAL_FETCH_URL);
+        setState({ hasAccess: true, isLoading: false });
+      } catch (err) {
+        const status = err?.response?.status ?? err?.status;
+        setState({
+          hasAccess: status === 403 ? false : true,
+          isLoading: false,
+        });
+      }
+    };
+
+    probe();
+  }, [axios]);
+
+  return state;
+};

--- a/src/Utilities/hooks/useInventoryHostsReadKesselProbe.test.js
+++ b/src/Utilities/hooks/useInventoryHostsReadKesselProbe.test.js
@@ -1,0 +1,60 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useInventoryHostsReadKesselProbe } from './useInventoryHostsReadKesselProbe';
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import { INVENTORY_TOTAL_FETCH_URL } from '../../AppConstants';
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/interceptors',
+  () => ({
+    useAxiosWithPlatformInterceptors: jest.fn(),
+  }),
+);
+
+describe('useInventoryHostsReadKesselProbe', () => {
+  beforeEach(() => {
+    useAxiosWithPlatformInterceptors.mockReset();
+  });
+
+  it('sets hasAccess true when the probe succeeds', async () => {
+    const get = jest.fn().mockResolvedValue({ data: {} });
+    useAxiosWithPlatformInterceptors.mockReturnValue({ get });
+
+    const { result } = renderHook(() => useInventoryHostsReadKesselProbe());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(get).toHaveBeenCalledWith(INVENTORY_TOTAL_FETCH_URL);
+    expect(result.current.hasAccess).toBe(true);
+  });
+
+  it('sets hasAccess false when the probe returns 403', async () => {
+    const err = { response: { status: 403 } };
+    const get = jest.fn().mockRejectedValue(err);
+    useAxiosWithPlatformInterceptors.mockReturnValue({ get });
+
+    const { result } = renderHook(() => useInventoryHostsReadKesselProbe());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasAccess).toBe(false);
+  });
+
+  it('sets hasAccess true on non-403 errors (same as inventory probe)', async () => {
+    const get = jest.fn().mockRejectedValue({ response: { status: 500 } });
+    useAxiosWithPlatformInterceptors.mockReturnValue({ get });
+
+    const { result } = renderHook(() => useInventoryHostsReadKesselProbe());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasAccess).toBe(true);
+  });
+});


### PR DESCRIPTION
When I was implementing kessel I wrongly looked at inventory component. so now implementing it proper way
if kessel enabled - we check if we have an access to at least 1 host (relying on backend for permissions).

### How to test:

1. Login as `comp-user-3` as it has kessel FF enabled
2. Navigate to dashboard and see that Inventory component is displayed (before the fix you would see that no permissions)