### PR TITLE
fix(RHINENG-26010): follow up for Darkmode

### DIFF
--- a/src/PresentationalComponents/RegisterSystemList.js
+++ b/src/PresentationalComponents/RegisterSystemList.js
@@ -35,7 +35,13 @@ const registerSystemsList = (item) => {
   item.linkWithinText ? (
     <React.Fragment>
       <p className="pf-v6-u-pl-md">
-        {item.partOne} <a href={item.linkWithinText}>{item.anchorText}</a>{' '}
+        {item.partOne}{' '}
+        <a
+          style={{ color: 'var(--pf-t--color--blue--50)' }}
+          href={item.linkWithinText}
+        >
+          {item.anchorText}
+        </a>{' '}
         {item.partTwo}
       </p>
     </React.Fragment>

--- a/src/PresentationalComponents/ZeroState/ZeroStateBanner.js
+++ b/src/PresentationalComponents/ZeroState/ZeroStateBanner.js
@@ -99,8 +99,12 @@ const ZeroStateBanner = ({
                 direction={{ default: 'column' }}
                 style={{ color: '#151515' }}
               >
-                <a className="pf-v6-u-pb-sm" onClick={updateRegisterButton}>
-                  Go Back
+                <a
+                  style={{ color: 'var(--pf-t--color--blue--50)' }}
+                  className="pf-v6-u-pb-sm"
+                  onClick={updateRegisterButton}
+                >
+                  Go back
                 </a>
                 {commands.map((item) => registerSystemsList(item))}
               </Flex>


### PR DESCRIPTION
Small follow up (I forgot about this UI content). Fixing link colors for darkmode and also fix wording

Before
<img width="2473" height="999" alt="image" src="https://github.com/user-attachments/assets/6a95b459-e722-400c-9465-e28455018895" />

After
<img width="2482" height="970" alt="image" src="https://github.com/user-attachments/assets/fc45cde1-1a2c-4cfe-8b01-ae02dd79ae1d" />
