### PR TITLE
HMS-10192: update Content Management zero state copy

### DIFF
--- a/src/PresentationalComponents/ZeroState/AppZeroState.test.js
+++ b/src/PresentationalComponents/ZeroState/AppZeroState.test.js
@@ -162,6 +162,30 @@ describe('AppZeroState component', () => {
     expect(zeroStateBanner).not.toBeInTheDocument();
   });
 
+  it('renders content management banner title from zero state constants', async () => {
+    render(
+      <MemoryRouter initialEntries={['/some-path']}>
+        <Routes>
+          <Route
+            path="/some-path"
+            element={
+              <AppZeroState
+                app="Content_management"
+                customFetchResults={false}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Content lifecycle management',
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('renders zero state with Red Hat Lightspeed branding', async () => {
     render(
       <MemoryRouter initialEntries={['/some-path']}>

--- a/src/PresentationalComponents/ZeroState/ZeroStateBanner.js
+++ b/src/PresentationalComponents/ZeroState/ZeroStateBanner.js
@@ -29,14 +29,12 @@ const ZeroStateBanner = ({
   appId,
 }) => {
   const zeroStateConstants = getZeroStateConstants();
-  const description =
-    zeroStateConstants[`${appName.toUpperCase()}_ZERO_STATE`].header
-      .description;
-  const commands =
-    zeroStateConstants[`${appName.toUpperCase()}_ZERO_STATE`].header.commands;
-  const bulletPoints =
-    zeroStateConstants[`${appName.toUpperCase()}_ZERO_STATE`].header
-      .bulletPoints;
+  const header =
+    zeroStateConstants[`${appName.toUpperCase()}_ZERO_STATE`].header;
+  const description = header.description;
+  const commands = header.commands;
+  const bulletPoints = header.bulletPoints;
+  const bannerTitle = header.title ?? appName.replace('_', ' ');
   const intl = useIntl();
   const { hideGlobalFilter } = useChrome();
 
@@ -69,7 +67,7 @@ const ZeroStateBanner = ({
             <Flex direction={{ default: 'column' }}>
               <FlexItem>
                 <Title headingLevel="h1" size="4xl">
-                  {appName.replace('_', ' ')}
+                  {bannerTitle}
                 </Title>
               </FlexItem>
               <FlexItem spacer={{ default: 'spacerXl' }}>

--- a/src/PresentationalComponents/ZeroState/zeroStateConstants.js
+++ b/src/PresentationalComponents/ZeroState/zeroStateConstants.js
@@ -182,7 +182,9 @@ const getInsightsZeroState = () => ({
 
 const getContentManagementZeroState = () => ({
   header: {
-    description: `${formatBrandName(ZERO_STATE_BRAND_NAME, true)} gives you the information to confidently update your RHEL systems with Red Hat product advisories and packages.`,
+    title: 'Content lifecycle management',
+    description:
+      'Manage system content and patch updates by creating content templates that control which advisories and package versions are applied to your RHEL systems.',
     commands: [
       { plainText: ' 1. Register your host' },
       {
@@ -204,9 +206,8 @@ const getContentManagementZeroState = () => ({
       },
     ],
     bulletPoints: [
-      'View and report on Red Hat product advisories that impact your RHEL environment and apply patches with Ansible Remediation.',
-      'Inspect the packages and versions deployed across your RHEL environment.',
-      'Add custom repositories and use that content to build customized RHEL images.',
+      'Create templates with repository snapshots to control exactly when updates are applied and to ensure identical patch levels across all your assigned systems.',
+      'Integrate custom content: Manage external repositories and your own RPMs alongside Red Hat sources.',
     ],
   },
   otherApps: [


### PR DESCRIPTION
feat(zerostate): update Content Management zero state copy for HMS-10192

Align the federated zero state description and bullet points with the Content Management zero state mock so content-sources can show template- focused onboarding text when users have no custom repos or templates.


[[UI] update zero state to include templates](https://redhat.atlassian.net/browse/HMS-10192)