### PR TITLE
fix: Add RHEL 10 to list of releases

### DIFF
--- a/src/PresentationalComponents/ZeroState/zeroStateConstants.js
+++ b/src/PresentationalComponents/ZeroState/zeroStateConstants.js
@@ -188,7 +188,7 @@ const getContentManagementZeroState = () => ({
     commands: [
       { plainText: ' 1. Register your host' },
       {
-        instructions: 'RHEL 7, 8 and 9:',
+        instructions: 'RHEL 7, 8, 9, and 10:',
         command: 'subscription-manager register',
       },
       {


### PR DESCRIPTION
Add RHEL 10 to the list of releases that can be used with the given instructions.